### PR TITLE
docs: 로그인 로그아웃 api docs 추가

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -76,3 +76,27 @@ include::{snippets}/auth-controller-test/kakao-login-callback/http-response.adoc
 ==== 응답
 
 include::{snippets}/auth-controller-test/kakao-login-callback/response-body.adoc[]
+
+== 로그아웃
+
+서비스와 카카오 로그아웃을 처리합니다.
+
+=== Example
+
+include::{snippets}/auth-controller-test/kakao-logout/curl-request.adoc[]
+
+=== HTTP
+
+==== 요청
+
+include::{snippets}/auth-controller-test/kakao-logout/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/auth-controller-test/kakao-logout/http-response.adoc[]
+
+=== Body
+
+==== 응답
+
+include::{snippets}/auth-controller-test/kakao-logout/response-body.adoc[]

--- a/src/docs/asciidoc/expense.adoc
+++ b/src/docs/asciidoc/expense.adoc
@@ -196,3 +196,5 @@ include::{snippets}/expense-controller-test/update-img-url-success/http-response
 ==== 요청
 
 include::{snippets}/expense-controller-test/update-img-url-success/request-body.adoc[]
+
+operation::create-expense[snippets="path-parameters,http-request,request-body,request-fields,http-response"]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,6 +7,9 @@
 :toclevels: 2
 :sectnums:
 
+
+include::auth.adoc[]
+
 include::character.adoc[]
 
 include::expense.adoc[]

--- a/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.dnd.moddo.domain.auth.controller;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.cookies.CookieDocumentation.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -42,8 +43,8 @@ class AuthControllerTest extends RestDocsTestSupport {
 			.andExpect(jsonPath("$.refreshToken").value("refresh-token"))
 			.andExpect(jsonPath("$.isMember").value(false))
 			.andDo(restDocs.document(
-				responseHeaders(
-					headerWithName("Set-Cookie").description("엑세스 토큰")
+				responseCookies(
+					cookieWithName("accessToken").description("엑세스 토큰")
 				),
 				responseFields(
 					fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰"),
@@ -93,12 +94,12 @@ class AuthControllerTest extends RestDocsTestSupport {
 		mockMvc.perform(get("/api/v1/login/oauth2/callback")
 				.param("code", "test code"))
 			.andExpect(status().isOk())
-			.andDo(restDocs.document(
+			.andDo(document("login",
 				queryParameters(
 					parameterWithName("code").description("카카오 인가 코드")
 				),
-				responseHeaders(
-					headerWithName("Set-Cookie").description("엑세스 토큰")
+				responseCookies(
+					cookieWithName("accessToken").description("엑세스 토큰")
 				)
 			));
 	}
@@ -114,7 +115,7 @@ class AuthControllerTest extends RestDocsTestSupport {
 		mockMvc.perform(get("/api/v1/logout")
 				.cookie(new Cookie("accessToken", "access-token")))
 			.andExpect(status().isOk())
-			.andDo(restDocs.document(
+			.andDo(document("logout",
 				requestCookies(
 					cookieWithName("accessToken").description("액세스 토큰")
 				),

--- a/src/test/java/com/dnd/moddo/domain/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/controller/ExpenseControllerTest.java
@@ -4,7 +4,10 @@ import static com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
@@ -13,6 +16,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
@@ -74,7 +78,21 @@ public class ExpenseControllerTest extends RestDocsTestSupport {
 				.param("groupToken", groupToken)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+			.andDo(document("create-expense",
+				requestFields(
+					fieldWithPath("expenses").type(JsonFieldType.ARRAY).description("지출 항목 목록"),
+					fieldWithPath("expenses[].amount").type(JsonFieldType.NUMBER).description("지출 금액"),
+					fieldWithPath("expenses[].content").type(JsonFieldType.STRING).description("지출 내용"),
+					fieldWithPath("expenses[].date").type(JsonFieldType.STRING).description("지출 일자 (yyyy-MM-dd)"),
+					fieldWithPath("expenses[].memberExpenses").type(JsonFieldType.ARRAY).description("멤버별 지출 내역"),
+					fieldWithPath("expenses[].memberExpenses[].id").type(JsonFieldType.NUMBER)
+						.description("멤버 ID"),
+					fieldWithPath("expenses[].memberExpenses[].amount").type(JsonFieldType.NUMBER)
+						.description("멤버가 실제로 부담한 금액")
+				))
+			)
+		;
 	}
 
 	@Test
@@ -123,7 +141,28 @@ public class ExpenseControllerTest extends RestDocsTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.expenses.length()").value(4))
 			.andExpect(jsonPath("$.expenses[0].id").value(1))
-			.andExpect(jsonPath("$.expenses[0].memberExpenses[0].name").value("김모또"));
+			.andExpect(jsonPath("$.expenses[0].memberExpenses[0].name").value("김모또"))
+			.andDo(document("get-expenses",
+				queryParameters(
+					parameterWithName("groupToken").description("조회할 그룹 토큰")
+				),
+				responseFields(
+					fieldWithPath("expenses").type(JsonFieldType.ARRAY).description("지출 내역 목록"),
+					fieldWithPath("expenses[].id").type(JsonFieldType.NUMBER).description("지출 ID"),
+					fieldWithPath("expenses[].amount").type(JsonFieldType.NUMBER).description("지출 금액"),
+					fieldWithPath("expenses[].content").type(JsonFieldType.STRING).description("지출 내역 내용"),
+					fieldWithPath("expenses[].date").type(JsonFieldType.STRING).description("지출 날짜 (yyyy-MM-dd)"),
+					fieldWithPath("expenses[].memberExpenses").type(JsonFieldType.ARRAY).description("멤버별 지출 상세"),
+					fieldWithPath("expenses[].memberExpenses[].id").type(JsonFieldType.NUMBER).description("멤버 ID"),
+					fieldWithPath("expenses[].memberExpenses[].name").type(JsonFieldType.STRING).description("멤버 이름"),
+					fieldWithPath("expenses[].memberExpenses[].role").type(JsonFieldType.STRING)
+						.description("멤버 역할(MANAGER/PARTICIPANT)"),
+					fieldWithPath("expenses[].memberExpenses[].profile").type(JsonFieldType.STRING)
+						.description("프로필 이미지 URL"),
+					fieldWithPath("expenses[].memberExpenses[].amount").type(JsonFieldType.NUMBER)
+						.description("해당 멤버의 지출 금액")
+				)
+			));
 	}
 
 	@Test


### PR DESCRIPTION
### #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호

### 🔀반영 브랜치
feat/#140-kakao-login
### 🔧변경 사항
- 인증 관련 누락된 API와 로그아웃 안내를 문서에 반영했습니다.

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
