### PR TITLE
fix: 도메인 변경에 따른 Docs url 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@
 </table>
 
 ### 7. 관련 문서
- 1. [API문서](https://moddo.kro.kr/docs/index.html)
+ 1. [API문서](https://api.moddo.kr/docs/index.html)

--- a/src/test/java/com/dnd/moddo/global/util/RestDocsTestSupport.java
+++ b/src/test/java/com/dnd/moddo/global/util/RestDocsTestSupport.java
@@ -38,7 +38,7 @@ public abstract class RestDocsTestSupport extends ControllerTest {
 				.withRequestDefaults(
 					modifyUris()
 						.scheme("https")
-						.host("moddo.kro.kr")
+						.host("api.moddo.kr")
 						.removePort(),
 					prettyPrint()
 				)


### PR DESCRIPTION
### #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호

### 🔀반영 브랜치
> ex) feat/#23-user-signup -> develop

### 🔧변경 사항
- Docs의 도메인을 `moddo.kro.kr -> api.moddo.kr`로 변경했습니다.

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
