### PR TITLE
fix: HttpOnly 쿠키 기반 로그인 흐름 강화

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -5,6 +5,7 @@
 == 게스트 토큰 발급
 
 비회원의 토큰을 발급받을 수 있습니다.
+발급된 `Access Token`과 `Refresh Token`은 HttpOnly 쿠키로도 함께 전달됩니다.
 
 - 비회원 토큰의 만료일은 발급일로부터 1개월입니다.
 
@@ -22,15 +23,10 @@ include::{snippets}/auth-controller-test/get-guest-token/http-request.adoc[]
 
 include::{snippets}/auth-controller-test/get-guest-token/http-response.adoc[]
 
-=== Body
-
-==== 응답
-
-include::{snippets}/auth-controller-test/get-guest-token/response-body.adoc[]
-
 == 액세스 토큰 재발급
 
-`refreshToken`을 사용해 `accessToken`을 재발급받을 수 있습니다.
+쿠키에 저장된 `refreshToken`을 사용해 `accessToken`을 재발급받을 수 있습니다.
+재발급된 `accessToken`은 HttpOnly 쿠키로도 함께 전달됩니다.
 
 === Example
 
@@ -46,16 +42,11 @@ include::{snippets}/auth-controller-test/reissue-access-token/http-request.adoc[
 
 include::{snippets}/auth-controller-test/reissue-access-token/http-response.adoc[]
 
-=== Body
-
-==== 응답
-
-include::{snippets}/auth-controller-test/reissue-access-token/response-body.adoc[]
-
 == 카카오톡 소셜 로그인
 
 사용자가 카카오 소셜 로그인을 완료하면 인가 코드를 통해 카카오 `Access Token`을 발급받습니다.
-발급된 토큰으로 카카오 사용자 정보를 조회한 뒤, 서비스의 `Access Token`을 생성해 쿠키로 전달합니다.
+발급된 토큰으로 카카오 사용자 정보를 조회한 뒤, 서비스의 `Access Token`과 `Refresh Token`을 쿠키로 전달합니다.
+`state`로 전달된 URL의 origin이 허용 목록에 포함될 때만 해당 URL로 리다이렉트하며, 그 외에는 요청 환경에 따라 로컬은 `http://localhost:3000`, 운영은 `https://www.moddo.kr`로 리다이렉트합니다.
 
 === Example
 
@@ -70,12 +61,6 @@ include::{snippets}/auth-controller-test/kakao-login-callback/http-request.adoc[
 ==== 응답
 
 include::{snippets}/auth-controller-test/kakao-login-callback/http-response.adoc[]
-
-=== Body
-
-==== 응답
-
-include::{snippets}/auth-controller-test/kakao-login-callback/response-body.adoc[]
 
 == 로그아웃
 

--- a/src/main/java/com/dnd/moddo/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/dnd/moddo/auth/application/RefreshTokenService.java
@@ -21,24 +21,32 @@ public class RefreshTokenService {
 	private final JwtProvider jwtProvider;
 
 	public RefreshResponse execute(String token) {
-
-		Long userId;
-
 		try {
-			userId = jwtUtil.getJwt(token).getBody().get(JwtConstants.AUTH_ID.message, Long.class);
+			String tokenType = jwtProvider.getTokenType(token);
+			if (!JwtConstants.REFRESH_KEY.message.equals(tokenType)) {
+				throw new TokenInvalidException();
+			}
+
+			Long userId = jwtUtil.getJwt(token)
+				.getBody()
+				.get(JwtConstants.AUTH_ID.message, Long.class);
+
+			if (userId == null) {
+				throw new TokenInvalidException();
+			}
+
+			User user = userRepository.getById(userId);
+			String newAccessToken = jwtProvider.generateAccessToken(
+				user.getId(),
+				user.getAuthority().toString()
+			);
+
+			return RefreshResponse.builder()
+				.accessToken(newAccessToken)
+				.build();
 		} catch (Exception e) {
 			throw new TokenInvalidException();
 		}
-
-		if (userId == null) {
-			throw new TokenInvalidException();
-		}
-
-		User user = userRepository.getById(userId);
-		String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getAuthority().toString());
-
-		return RefreshResponse.builder()
-			.accessToken(newAccessToken)
-			.build();
 	}
+
 }

--- a/src/main/java/com/dnd/moddo/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/dnd/moddo/auth/application/RefreshTokenService.java
@@ -22,15 +22,19 @@ public class RefreshTokenService {
 
 	public RefreshResponse execute(String token) {
 
-		String email;
+		Long userId;
 
 		try {
-			email = jwtUtil.getJwt(jwtUtil.parseToken(token)).getBody().get(JwtConstants.EMAIL.message).toString();
+			userId = jwtUtil.getJwt(token).getBody().get(JwtConstants.AUTH_ID.message, Long.class);
 		} catch (Exception e) {
 			throw new TokenInvalidException();
 		}
 
-		User user = userRepository.getByEmail(email);
+		if (userId == null) {
+			throw new TokenInvalidException();
+		}
+
+		User user = userRepository.getById(userId);
 		String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getAuthority().toString());
 
 		return RefreshResponse.builder()

--- a/src/main/java/com/dnd/moddo/auth/infrastructure/security/JwtFilter.java
+++ b/src/main/java/com/dnd/moddo/auth/infrastructure/security/JwtFilter.java
@@ -27,20 +27,15 @@ public class JwtFilter extends OncePerRequestFilter {
 		String token = jwtUtil.resolveToken(request);
 
 		if (token != null) {
-			String requestURI = request.getRequestURI();
-			String expectedTokenType = getExpectedTokenType(requestURI);
-
-			Authentication authentication = jwtAuth.getAuthentication(token, expectedTokenType);
+			Authentication authentication = jwtAuth.getAuthentication(token, JwtConstants.ACCESS_KEY.message);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
 		}
 
 		filterChain.doFilter(request, response);
 	}
 
-	private String getExpectedTokenType(String requestURI) {
-		if (requestURI.startsWith("/api/v1/user/reissue/token")) {
-			return JwtConstants.REFRESH_KEY.message;
-		}
-		return JwtConstants.ACCESS_KEY.message;
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return request.getRequestURI().startsWith("/api/v1/user/reissue/token");
 	}
 }

--- a/src/main/java/com/dnd/moddo/auth/presentation/AuthController.java
+++ b/src/main/java/com/dnd/moddo/auth/presentation/AuthController.java
@@ -88,20 +88,22 @@ public class AuthController {
 	@PostMapping("/logout")
 	public ResponseEntity<?> kakaoLogout(@CookieValue(value = "accessToken") String token,
 		@LoginUser LoginUserInfo loginUser) {
-		String cookie = authCookieManager.expireCookie("accessToken");
+		String accessTokenCookie = authCookieManager.expireCookie("accessToken");
+		String refreshTokenCookie = authCookieManager.expireCookie("refreshToken");
 		authService.logout(loginUser.userId());
 		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, cookie)
+			.header(HttpHeaders.SET_COOKIE, accessTokenCookie, refreshTokenCookie)
 			.body(Collections.singletonMap("message", "Logout successful"));
 	}
 
 	@DeleteMapping("/unlink")
 	public ResponseEntity<?> kakaoUnlink(@CookieValue(value = "accessToken") String token,
 		@LoginUser LoginUserInfo loginUser) {
-		String cookie = authCookieManager.expireCookie("accessToken");
+		String accessTokenCookie = authCookieManager.expireCookie("accessToken");
+		String refreshTokenCookie = authCookieManager.expireCookie("refreshToken");
 		authService.unlink(loginUser.userId());
 		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, cookie)
+			.header(HttpHeaders.SET_COOKIE, accessTokenCookie, refreshTokenCookie)
 			.body(Collections.singletonMap("message", "Unlink successful"));
 	}
 

--- a/src/main/java/com/dnd/moddo/auth/presentation/AuthController.java
+++ b/src/main/java/com/dnd/moddo/auth/presentation/AuthController.java
@@ -2,12 +2,10 @@ package com.dnd.moddo.auth.presentation;
 
 import static com.dnd.moddo.auth.infrastructure.security.JwtConstants.*;
 
-import java.io.IOException;
 import java.util.Collections;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -15,7 +13,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,14 +23,12 @@ import com.dnd.moddo.auth.infrastructure.security.JwtProvider;
 import com.dnd.moddo.auth.infrastructure.security.LoginUser;
 import com.dnd.moddo.auth.presentation.response.AuthCheckResponse;
 import com.dnd.moddo.auth.presentation.response.LoginUserInfo;
-import com.dnd.moddo.auth.presentation.response.RefreshResponse;
 import com.dnd.moddo.auth.presentation.response.TokenResponse;
-import com.dnd.moddo.common.config.CookieProperties;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
-import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
@@ -45,46 +40,55 @@ public class AuthController {
 
 	private final AuthService authService;
 	private final RefreshTokenService refreshTokenService;
-	private final CookieProperties cookieProperties;
 	private final JwtProvider jwtProvider;
+	private final AuthCookieManager authCookieManager;
+	private final AuthRedirectResolver authRedirectResolver;
 
 	@GetMapping("/user/guest/token")
-	public ResponseEntity<TokenResponse> getGuestToken() {
+	public ResponseEntity<Void> getGuestToken() {
 		TokenResponse tokenResponse = authService.loginWithGuest();
 
-		String cookie = createCookie("accessToken", tokenResponse.accessToken()).toString();
+		String accessTokenCookie = authCookieManager.createCookie("accessToken", tokenResponse.accessToken());
+		String refreshTokenCookie = authCookieManager.createCookie("refreshToken", tokenResponse.refreshToken());
 
 		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, cookie)
-			.body(tokenResponse);
+			.header(HttpHeaders.SET_COOKIE, accessTokenCookie, refreshTokenCookie)
+			.build();
 	}
 
 	@PutMapping("/user/reissue/token")
-	public RefreshResponse reissueAccessToken(@RequestHeader(value = "Authorization") @NotBlank String refreshToken) {
-		return refreshTokenService.execute(refreshToken);
+	public ResponseEntity<Void> reissueAccessToken(
+		@CookieValue(value = "refreshToken") @NotBlank String refreshToken
+	) {
+		String accessToken = refreshTokenService.execute(refreshToken).getAccessToken();
+		String accessTokenCookie = authCookieManager.createCookie("accessToken", accessToken);
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, accessTokenCookie)
+			.build();
 	}
 
 	@GetMapping("/login/oauth2/callback")
-	public ResponseEntity<?> kakaoLoginCallback(@RequestParam @NotBlank String code,
-		HttpServletResponse response) throws
-		IOException {
+	public ResponseEntity<Void> kakaoLoginCallback(@RequestParam @NotBlank String code,
+		@RequestParam @NotBlank String state,
+		HttpServletRequest request) {
 
 		TokenResponse tokenResponse = authService.loginOrRegisterWithKakao(code);
+		String redirectUrl = authRedirectResolver.resolve(state, request);
 
-		String cookie = createCookie("accessToken", tokenResponse.accessToken()).toString();
-		response.addHeader("Set-Cookie", cookie);
-		response.sendRedirect("https://www.moddo.kr");
+		String accessTokenCookie = authCookieManager.createCookie("accessToken", tokenResponse.accessToken());
+		String refreshTokenCookie = authCookieManager.createCookie("refreshToken", tokenResponse.refreshToken());
 
 		return ResponseEntity.status(HttpStatus.FOUND)
-			.header(HttpHeaders.LOCATION, "https://www.moddo.kr")
-			.header(HttpHeaders.SET_COOKIE, cookie)
+			.header(HttpHeaders.LOCATION, redirectUrl)
+			.header(HttpHeaders.SET_COOKIE, accessTokenCookie, refreshTokenCookie)
 			.build();
 	}
 
 	@PostMapping("/logout")
 	public ResponseEntity<?> kakaoLogout(@CookieValue(value = "accessToken") String token,
 		@LoginUser LoginUserInfo loginUser) {
-		String cookie = expireCookie("accessToken").toString();
+		String cookie = authCookieManager.expireCookie("accessToken");
 		authService.logout(loginUser.userId());
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, cookie)
@@ -94,7 +98,7 @@ public class AuthController {
 	@DeleteMapping("/unlink")
 	public ResponseEntity<?> kakaoUnlink(@CookieValue(value = "accessToken") String token,
 		@LoginUser LoginUserInfo loginUser) {
-		String cookie = expireCookie("accessToken").toString();
+		String cookie = authCookieManager.expireCookie("accessToken");
 		authService.unlink(loginUser.userId());
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, cookie)
@@ -130,27 +134,6 @@ public class AuthController {
 				AuthCheckResponse.fail(AuthCheckResponse.AuthFailReason.INVALID_TOKEN)
 			);
 		}
-	}
-
-	private ResponseCookie createCookie(String name, String key) {
-		return ResponseCookie.from(name, key)
-			.httpOnly(cookieProperties.httpOnly())
-			.secure(cookieProperties.secure())
-			.path(cookieProperties.path())
-			.sameSite(cookieProperties.sameSite())
-			.maxAge(cookieProperties.maxAge())
-			.build();
-
-	}
-
-	private ResponseCookie expireCookie(String name) {
-		return ResponseCookie.from(name, null)
-			.httpOnly(cookieProperties.httpOnly())
-			.secure(cookieProperties.secure())
-			.path(cookieProperties.path())
-			.sameSite(cookieProperties.sameSite())
-			.maxAge(0L)
-			.build();
 	}
 
 }

--- a/src/main/java/com/dnd/moddo/auth/presentation/AuthCookieManager.java
+++ b/src/main/java/com/dnd/moddo/auth/presentation/AuthCookieManager.java
@@ -1,0 +1,37 @@
+package com.dnd.moddo.auth.presentation;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import com.dnd.moddo.common.config.CookieProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthCookieManager {
+
+	private final CookieProperties cookieProperties;
+
+	public String createCookie(String name, String value) {
+		return ResponseCookie.from(name, value)
+			.httpOnly(cookieProperties.httpOnly())
+			.secure(cookieProperties.secure())
+			.path(cookieProperties.path())
+			.sameSite(cookieProperties.sameSite())
+			.maxAge(cookieProperties.maxAge())
+			.build()
+			.toString();
+	}
+
+	public String expireCookie(String name) {
+		return ResponseCookie.from(name, null)
+			.httpOnly(cookieProperties.httpOnly())
+			.secure(cookieProperties.secure())
+			.path(cookieProperties.path())
+			.sameSite(cookieProperties.sameSite())
+			.maxAge(0L)
+			.build()
+			.toString();
+	}
+}

--- a/src/main/java/com/dnd/moddo/auth/presentation/AuthRedirectResolver.java
+++ b/src/main/java/com/dnd/moddo/auth/presentation/AuthRedirectResolver.java
@@ -1,0 +1,59 @@
+package com.dnd.moddo.auth.presentation;
+
+import java.net.URI;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class AuthRedirectResolver {
+
+	private static final String DEFAULT_LOCAL_REDIRECT_URL = "http://localhost:3000";
+	private static final String DEFAULT_PROD_REDIRECT_URL = "https://www.moddo.kr";
+
+	private static final Set<String> ALLOWED_REDIRECT_ORIGINS = Set.of(
+		"http://localhost:3000",
+		"https://moddo-frontend.pages.dev",
+		"https://www.moddo.kr",
+		"https://moddo.kr"
+	);
+
+	public String resolve(String state, HttpServletRequest request) {
+		try {
+			URI uri = URI.create(state);
+			String origin = extractOrigin(uri);
+
+			if (origin != null && ALLOWED_REDIRECT_ORIGINS.contains(origin)) {
+				return uri.toString();
+			}
+		} catch (IllegalArgumentException ignored) {
+			// Fallback to the default URL when state is not a valid redirect URL.
+		}
+
+		return isLocalRequest(request) ? DEFAULT_LOCAL_REDIRECT_URL : DEFAULT_PROD_REDIRECT_URL;
+	}
+
+	private String extractOrigin(URI uri) {
+		if (!uri.isAbsolute() || uri.getScheme() == null || uri.getHost() == null) {
+			return null;
+		}
+
+		StringBuilder origin = new StringBuilder()
+			.append(uri.getScheme().toLowerCase())
+			.append("://")
+			.append(uri.getHost().toLowerCase());
+
+		if (uri.getPort() != -1) {
+			origin.append(":").append(uri.getPort());
+		}
+
+		return origin.toString();
+	}
+
+	private boolean isLocalRequest(HttpServletRequest request) {
+		String serverName = request.getServerName();
+		return "localhost".equalsIgnoreCase(serverName) || "127.0.0.1".equals(serverName);
+	}
+}

--- a/src/main/java/com/dnd/moddo/auth/presentation/AuthRedirectResolver.java
+++ b/src/main/java/com/dnd/moddo/auth/presentation/AuthRedirectResolver.java
@@ -1,38 +1,34 @@
 package com.dnd.moddo.auth.presentation;
 
 import java.net.URI;
-import java.util.Set;
-
 import org.springframework.stereotype.Component;
 
+import com.dnd.moddo.common.config.FrontendProperties;
+
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class AuthRedirectResolver {
 
-	private static final String DEFAULT_LOCAL_REDIRECT_URL = "http://localhost:3000";
-	private static final String DEFAULT_PROD_REDIRECT_URL = "https://www.moddo.kr";
-
-	private static final Set<String> ALLOWED_REDIRECT_ORIGINS = Set.of(
-		"http://localhost:3000",
-		"https://moddo-frontend.pages.dev",
-		"https://www.moddo.kr",
-		"https://moddo.kr"
-	);
+	private final FrontendProperties frontendProperties;
 
 	public String resolve(String state, HttpServletRequest request) {
 		try {
 			URI uri = URI.create(state);
 			String origin = extractOrigin(uri);
 
-			if (origin != null && ALLOWED_REDIRECT_ORIGINS.contains(origin)) {
+			if (origin != null && frontendProperties.redirectAllowedOrigins().contains(origin)) {
 				return uri.toString();
 			}
 		} catch (IllegalArgumentException ignored) {
 			// Fallback to the default URL when state is not a valid redirect URL.
 		}
 
-		return isLocalRequest(request) ? DEFAULT_LOCAL_REDIRECT_URL : DEFAULT_PROD_REDIRECT_URL;
+		return isLocalRequest(request)
+			? frontendProperties.defaultLocalRedirectUrl()
+			: frontendProperties.defaultProdRedirectUrl();
 	}
 
 	private String extractOrigin(URI uri) {

--- a/src/main/java/com/dnd/moddo/common/config/FrontendProperties.java
+++ b/src/main/java/com/dnd/moddo/common/config/FrontendProperties.java
@@ -1,0 +1,14 @@
+package com.dnd.moddo.common.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "frontend")
+public record FrontendProperties(
+	List<String> corsAllowedOrigins,
+	List<String> redirectAllowedOrigins,
+	String defaultLocalRedirectUrl,
+	String defaultProdRedirectUrl
+) {
+}

--- a/src/main/java/com/dnd/moddo/common/config/WebConfig.java
+++ b/src/main/java/com/dnd/moddo/common/config/WebConfig.java
@@ -15,11 +15,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 	private final LoginUserArgumentResolver loginUserArgumentResolver;
+	private final FrontendProperties frontendProperties;
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("https://www.moddo.kr", "http://localhost:3000", "http://localhost:4173")
+			.allowedOrigins(frontendProperties.corsAllowedOrigins().toArray(String[]::new))
 			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
 			.allowedHeaders("*")
 			.exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,19 @@ cookie:
   same-site: none
   max-age: 7D
 
+frontend:
+  cors-allowed-origins:
+    - https://www.moddo.kr
+    - http://localhost:3000
+    - http://localhost:4173
+  redirect-allowed-origins:
+    - http://localhost:3000
+    - https://moddo-frontend.pages.dev
+    - https://www.moddo.kr
+    - https://moddo.kr
+  default-local-redirect-url: http://localhost:3000
+  default-prod-redirect-url: https://www.moddo.kr
+
 ---
 
 spring:
@@ -58,7 +71,6 @@ spring:
       on-profile: prod
 
 ---
-
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,7 @@ kakao:
 
 cookie:
   secure: true
-  http-only: false
+  http-only: true
   path: /
   same-site: none
   max-age: 7D

--- a/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
@@ -181,9 +181,16 @@ class AuthControllerTest extends RestDocsTestSupport {
 		mockMvc.perform(post("/api/v1/logout")
 				.cookie(new Cookie("accessToken", "access-token")))
 			.andExpect(status().isOk())
+			.andExpect(header().stringValues(HttpHeaders.SET_COOKIE,
+				hasItems(org.hamcrest.Matchers.startsWith("accessToken="),
+					org.hamcrest.Matchers.startsWith("refreshToken="))))
 			.andDo(document("logout",
 				requestCookies(
 					cookieWithName("accessToken").description("액세스 토큰")
+				),
+				responseCookies(
+					cookieWithName("accessToken").description("만료된 액세스 토큰"),
+					cookieWithName("refreshToken").description("만료된 리프레시 토큰")
 				),
 				responseFields(
 					fieldWithPath("message").type(JsonFieldType.STRING).description("로그아웃 성공 메시지")

--- a/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
@@ -1,7 +1,9 @@
 package com.dnd.moddo.domain.auth.controller;
 
 import static com.dnd.moddo.auth.infrastructure.security.JwtConstants.*;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
 import static org.springframework.restdocs.cookies.CookieDocumentation.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
@@ -14,6 +16,7 @@ import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import com.dnd.moddo.auth.presentation.response.KakaoTokenResponse;
@@ -44,18 +47,13 @@ class AuthControllerTest extends RestDocsTestSupport {
 		// when & then
 		mockMvc.perform(get("/api/v1/user/guest/token"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.accessToken").value("access-token"))
-			.andExpect(jsonPath("$.refreshToken").value("refresh-token"))
-			.andExpect(jsonPath("$.isMember").value(false))
+			.andExpect(content().string(""))
+			.andExpect(cookie().exists("accessToken"))
+			.andExpect(cookie().exists("refreshToken"))
 			.andDo(restDocs.document(
 				responseCookies(
-					cookieWithName("accessToken").description("엑세스 토큰")
-				),
-				responseFields(
-					fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰"),
-					fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰"),
-					fieldWithPath("expiredAt").type(JsonFieldType.STRING).description("리프레시 토큰 만료 시간"),
-					fieldWithPath("isMember").type(JsonFieldType.BOOLEAN).description("회원 여부")
+					cookieWithName("accessToken").description("엑세스 토큰"),
+					cookieWithName("refreshToken").description("리프레시 토큰")
 				)
 			));
 	}
@@ -71,15 +69,16 @@ class AuthControllerTest extends RestDocsTestSupport {
 
 		// when & then
 		mockMvc.perform(put("/api/v1/user/reissue/token")
-				.header("Authorization", "Bearer refresh-token"))
+				.cookie(new Cookie("refreshToken", "refresh-token")))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.accessToken").value("new-access-token"))
+			.andExpect(content().string(""))
+			.andExpect(cookie().exists("accessToken"))
 			.andDo(restDocs.document(
-				requestHeaders(
-					headerWithName("Authorization").description("리프레시 토큰")
+				requestCookies(
+					cookieWithName("refreshToken").description("리프레시 토큰")
 				),
-				responseFields(
-					fieldWithPath("accessToken").type(JsonFieldType.STRING).description("새 액세스 토큰")
+				responseCookies(
+					cookieWithName("accessToken").description("새로 재발급된 액세스 토큰")
 				)
 			));
 	}
@@ -97,16 +96,73 @@ class AuthControllerTest extends RestDocsTestSupport {
 
 		//when & then
 		mockMvc.perform(get("/api/v1/login/oauth2/callback")
-				.param("code", "test code"))
+				.param("code", "test code")
+				.param("state", "http://localhost:3000/login/callback?next=%2Fhome"))
 			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("http://localhost:3000/login/callback?next=%2Fhome"))
+			.andExpect(header().stringValues(HttpHeaders.SET_COOKIE,
+				hasItems(org.hamcrest.Matchers.startsWith("accessToken="),
+					org.hamcrest.Matchers.startsWith("refreshToken="))))
 			.andDo(document("login",
 				queryParameters(
-					parameterWithName("code").description("카카오 인가 코드")
+					parameterWithName("code").description("카카오 인가 코드"),
+					parameterWithName("state").description(
+						"로그인 완료 후 이동할 URL. 허용된 origin만 리다이렉트되며, 그 외에는 요청 환경에 따라 localhost는 http://localhost:3000, 운영은 https://www.moddo.kr 로 대체됩니다.")
+				),
+				responseHeaders(
+					headerWithName(HttpHeaders.LOCATION).description("허용된 state URL 또는 fallback URL")
 				),
 				responseCookies(
-					cookieWithName("accessToken").description("엑세스 토큰")
+					cookieWithName("accessToken").description("엑세스 토큰"),
+					cookieWithName("refreshToken").description("리프레시 토큰")
 				)
 			));
+	}
+
+	@Test
+	@DisplayName("state의 origin이 허용 목록에 없으면 로컬 환경에서는 localhost:3000으로 리다이렉트한다.")
+	void kakaoLoginCallbackFallbackToLocalUrl() throws Exception {
+		// given
+		TokenResponse tokenResponse = new TokenResponse("access-token", "refresh-token",
+			ZonedDateTime.now().plusMonths(1), true);
+		given(authService.loginOrRegisterWithKakao(anyString())).willReturn(tokenResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/login/oauth2/callback")
+				.param("code", "test code")
+				.param("state", "https://malicious.example.com/login/callback")
+				.with(request -> {
+					request.setServerName("localhost");
+					request.setServerPort(8080);
+					return request;
+				}))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("http://localhost:3000"))
+			.andExpect(cookie().exists("accessToken"))
+			.andExpect(cookie().exists("refreshToken"));
+	}
+
+	@Test
+	@DisplayName("state의 origin이 허용 목록에 없으면 운영 환경에서는 www.moddo.kr로 리다이렉트한다.")
+	void kakaoLoginCallbackFallbackToProdUrl() throws Exception {
+		// given
+		TokenResponse tokenResponse = new TokenResponse("access-token", "refresh-token",
+			ZonedDateTime.now().plusMonths(1), true);
+		given(authService.loginOrRegisterWithKakao(anyString())).willReturn(tokenResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/login/oauth2/callback")
+				.param("code", "test code")
+				.param("state", "https://malicious.example.com/login/callback")
+				.with(request -> {
+					request.setServerName("api.moddo.kr");
+					request.setServerPort(443);
+					return request;
+				}))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("https://www.moddo.kr"))
+			.andExpect(cookie().exists("accessToken"))
+			.andExpect(cookie().exists("refreshToken"));
 	}
 
 	@Test

--- a/src/test/java/com/dnd/moddo/domain/auth/controller/AuthCookieManagerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/controller/AuthCookieManagerTest.java
@@ -1,0 +1,44 @@
+package com.dnd.moddo.domain.auth.controller;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.dnd.moddo.auth.presentation.AuthCookieManager;
+import com.dnd.moddo.common.config.CookieProperties;
+
+class AuthCookieManagerTest {
+
+	private final AuthCookieManager authCookieManager = new AuthCookieManager(
+		new CookieProperties(true, true, "/", "none", Duration.ofDays(7))
+	);
+
+	@Test
+	@DisplayName("인증 쿠키를 설정값에 맞춰 생성한다.")
+	void createCookie() {
+		String cookie = authCookieManager.createCookie("accessToken", "access-token");
+
+		assertThat(cookie).contains("accessToken=access-token");
+		assertThat(cookie).contains("Path=/");
+		assertThat(cookie).contains("Max-Age=604800");
+		assertThat(cookie).contains("Secure");
+		assertThat(cookie).contains("HttpOnly");
+		assertThat(cookie).contains("SameSite=none");
+	}
+
+	@Test
+	@DisplayName("만료 쿠키를 생성한다.")
+	void expireCookie() {
+		String cookie = authCookieManager.expireCookie("accessToken");
+
+		assertThat(cookie).contains("accessToken=");
+		assertThat(cookie).contains("Path=/");
+		assertThat(cookie).contains("Max-Age=0");
+		assertThat(cookie).contains("Secure");
+		assertThat(cookie).contains("HttpOnly");
+		assertThat(cookie).contains("SameSite=none");
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/auth/controller/AuthRedirectResolverTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/controller/AuthRedirectResolverTest.java
@@ -7,10 +7,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import com.dnd.moddo.auth.presentation.AuthRedirectResolver;
+import com.dnd.moddo.common.config.FrontendProperties;
 
 class AuthRedirectResolverTest {
 
-	private final AuthRedirectResolver authRedirectResolver = new AuthRedirectResolver();
+	private final AuthRedirectResolver authRedirectResolver = new AuthRedirectResolver(
+		new FrontendProperties(
+			java.util.List.of("https://www.moddo.kr", "http://localhost:3000", "http://localhost:4173"),
+			java.util.List.of("http://localhost:3000", "https://moddo-frontend.pages.dev", "https://www.moddo.kr",
+				"https://moddo.kr"),
+			"http://localhost:3000",
+			"https://www.moddo.kr"
+		)
+	);
 
 	@Test
 	@DisplayName("허용된 origin의 state는 그대로 리다이렉트한다.")

--- a/src/test/java/com/dnd/moddo/domain/auth/controller/AuthRedirectResolverTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/controller/AuthRedirectResolverTest.java
@@ -1,0 +1,67 @@
+package com.dnd.moddo.domain.auth.controller;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.dnd.moddo.auth.presentation.AuthRedirectResolver;
+
+class AuthRedirectResolverTest {
+
+	private final AuthRedirectResolver authRedirectResolver = new AuthRedirectResolver();
+
+	@Test
+	@DisplayName("허용된 origin의 state는 그대로 리다이렉트한다.")
+	void resolveAllowedState() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServerName("api.moddo.kr");
+
+		String redirectUrl = authRedirectResolver.resolve(
+			"https://www.moddo.kr/login/callback?next=%2Fhome",
+			request
+		);
+
+		assertThat(redirectUrl).isEqualTo("https://www.moddo.kr/login/callback?next=%2Fhome");
+	}
+
+	@Test
+	@DisplayName("허용되지 않은 origin의 state는 로컬 요청일 때 localhost로 대체한다.")
+	void fallbackToLocalUrlForInvalidOrigin() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServerName("localhost");
+
+		String redirectUrl = authRedirectResolver.resolve(
+			"https://malicious.example.com/login/callback",
+			request
+		);
+
+		assertThat(redirectUrl).isEqualTo("http://localhost:3000");
+	}
+
+	@Test
+	@DisplayName("허용되지 않은 origin의 state는 운영 요청일 때 운영 URL로 대체한다.")
+	void fallbackToProdUrlForInvalidOrigin() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServerName("api.moddo.kr");
+
+		String redirectUrl = authRedirectResolver.resolve(
+			"https://malicious.example.com/login/callback",
+			request
+		);
+
+		assertThat(redirectUrl).isEqualTo("https://www.moddo.kr");
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 state는 요청 환경에 맞는 기본 URL로 대체한다.")
+	void fallbackForMalformedState() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServerName("localhost");
+
+		String redirectUrl = authRedirectResolver.resolve("not-a-valid-url", request);
+
+		assertThat(redirectUrl).isEqualTo("http://localhost:3000");
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
@@ -47,7 +47,6 @@ public class RefreshTokenServiceTest {
 	public void reissueAccessToken() {
 		// given
 		String validToken = "validToken";
-		String email = "test@example.com";
 		Long userId = 1L;
 		String role = "USER";
 		String newAccessToken = "newAccessToken";
@@ -57,12 +56,12 @@ public class RefreshTokenServiceTest {
 
 		when(jwtUtil.getJwt(any())).thenReturn(mockJws);
 		when(mockJws.getBody()).thenReturn(mockClaims);
-		when(mockClaims.get(JwtConstants.EMAIL.message)).thenReturn(email);
+		when(mockClaims.get(JwtConstants.AUTH_ID.message, Long.class)).thenReturn(userId);
 
 		User user = createGuestDefault();
 		ReflectionTestUtils.setField(user, "id", userId);
 
-		when(userRepository.getByEmail(email)).thenReturn(user);
+		when(userRepository.getById(userId)).thenReturn(user);
 		when(jwtProvider.generateAccessToken(userId, role)).thenReturn(newAccessToken);
 
 		// when
@@ -70,7 +69,7 @@ public class RefreshTokenServiceTest {
 
 		// then
 		then(response.getAccessToken()).isEqualTo(newAccessToken);
-		verify(userRepository, times(1)).getByEmail(email);
+		verify(userRepository, times(1)).getById(userId);
 		verify(jwtProvider, times(1)).generateAccessToken(userId, role);
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
@@ -54,6 +54,7 @@ public class RefreshTokenServiceTest {
 		Jws<Claims> mockJws = mock(Jws.class);
 		Claims mockClaims = mock(Claims.class);
 
+		when(jwtProvider.getTokenType(validToken)).thenReturn(JwtConstants.REFRESH_KEY.message);
 		when(jwtUtil.getJwt(any())).thenReturn(mockJws);
 		when(mockJws.getBody()).thenReturn(mockClaims);
 		when(mockClaims.get(JwtConstants.AUTH_ID.message, Long.class)).thenReturn(userId);
@@ -77,6 +78,7 @@ public class RefreshTokenServiceTest {
 	public void shouldThrowOnInvalidToken() {
 		// given
 		String invalidToken = "invalidToken";
+		when(jwtProvider.getTokenType(invalidToken)).thenReturn(JwtConstants.REFRESH_KEY.message);
 		when(jwtUtil.getJwt(any())).thenThrow(new JwtException("Invalid token"));
 
 		// when & then
@@ -92,6 +94,7 @@ public class RefreshTokenServiceTest {
 		Jws<Claims> mockJws = mock(Jws.class);
 		Claims mockClaims = mock(Claims.class);
 
+		when(jwtProvider.getTokenType(tokenWithoutUserId)).thenReturn(JwtConstants.REFRESH_KEY.message);
 		when(jwtUtil.getJwt(tokenWithoutUserId)).thenReturn(mockJws);
 		when(mockJws.getBody()).thenReturn(mockClaims);
 		when(mockClaims.get(JwtConstants.AUTH_ID.message, Long.class)).thenReturn(null);
@@ -100,6 +103,21 @@ public class RefreshTokenServiceTest {
 		thenThrownBy(() -> refreshTokenService.execute(tokenWithoutUserId))
 			.isInstanceOf(TokenInvalidException.class);
 
+		verify(userRepository, never()).getById(anyLong());
+		verify(jwtProvider, never()).generateAccessToken(anyLong(), anyString());
+	}
+
+	@Test
+	public void shouldThrowWhenTokenTypeIsNotRefreshToken() {
+		// given
+		String accessToken = "accessToken";
+		when(jwtProvider.getTokenType(accessToken)).thenReturn(JwtConstants.ACCESS_KEY.message);
+
+		// when & then
+		thenThrownBy(() -> refreshTokenService.execute(accessToken))
+			.isInstanceOf(TokenInvalidException.class);
+
+		verify(jwtUtil, never()).getJwt(anyString());
 		verify(userRepository, never()).getById(anyLong());
 		verify(jwtProvider, never()).generateAccessToken(anyLong(), anyString());
 	}

--- a/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
@@ -83,4 +83,24 @@ public class RefreshTokenServiceTest {
 		thenThrownBy(() -> refreshTokenService.execute(invalidToken))
 			.isInstanceOf(TokenInvalidException.class);
 	}
+
+	@Test
+	public void shouldThrowWhenUserIdIsMissingInToken() {
+		// given
+		String tokenWithoutUserId = "tokenWithoutUserId";
+
+		Jws<Claims> mockJws = mock(Jws.class);
+		Claims mockClaims = mock(Claims.class);
+
+		when(jwtUtil.getJwt(tokenWithoutUserId)).thenReturn(mockJws);
+		when(mockJws.getBody()).thenReturn(mockClaims);
+		when(mockClaims.get(JwtConstants.AUTH_ID.message, Long.class)).thenReturn(null);
+
+		// when & then
+		thenThrownBy(() -> refreshTokenService.execute(tokenWithoutUserId))
+			.isInstanceOf(TokenInvalidException.class);
+
+		verify(userRepository, never()).getById(anyLong());
+		verify(jwtProvider, never()).generateAccessToken(anyLong(), anyString());
+	}
 }

--- a/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
+++ b/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
@@ -1,9 +1,15 @@
 package com.dnd.moddo.global.util;
 
+import static org.mockito.BDDMockito.given;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.dnd.moddo.auth.application.AuthService;
@@ -14,6 +20,8 @@ import com.dnd.moddo.auth.infrastructure.security.JwtFilter;
 import com.dnd.moddo.auth.infrastructure.security.JwtProvider;
 import com.dnd.moddo.auth.infrastructure.security.LoginUserArgumentResolver;
 import com.dnd.moddo.auth.presentation.AuthController;
+import com.dnd.moddo.auth.presentation.AuthCookieManager;
+import com.dnd.moddo.auth.presentation.AuthRedirectResolver;
 import com.dnd.moddo.common.config.CookieProperties;
 import com.dnd.moddo.common.logging.ErrorNotifier;
 import com.dnd.moddo.event.application.command.CommandExpenseService;
@@ -40,6 +48,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Disabled
+@Import({
+	AuthCookieManager.class,
+	AuthRedirectResolver.class
+})
 @WebMvcTest({
 	AuthController.class,
 	CharacterController.class,
@@ -126,6 +138,15 @@ public abstract class ControllerTest {
 
 	@MockBean
 	protected JwtProvider jwtProvider;
+
+	@BeforeEach
+	void setUpCookieProperties() {
+		given(cookieProperties.httpOnly()).willReturn(true);
+		given(cookieProperties.secure()).willReturn(true);
+		given(cookieProperties.path()).willReturn("/");
+		given(cookieProperties.sameSite()).willReturn("none");
+		given(cookieProperties.maxAge()).willReturn(Duration.ofDays(7));
+	}
 
 	protected String toJson(Object object) throws JsonProcessingException {
 		return objectMapper.writeValueAsString(object);

--- a/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
+++ b/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
@@ -23,6 +23,7 @@ import com.dnd.moddo.auth.presentation.AuthController;
 import com.dnd.moddo.auth.presentation.AuthCookieManager;
 import com.dnd.moddo.auth.presentation.AuthRedirectResolver;
 import com.dnd.moddo.common.config.CookieProperties;
+import com.dnd.moddo.common.config.FrontendProperties;
 import com.dnd.moddo.common.logging.ErrorNotifier;
 import com.dnd.moddo.event.application.command.CommandExpenseService;
 import com.dnd.moddo.event.application.command.CommandMemberService;
@@ -126,6 +127,9 @@ public abstract class ControllerTest {
 
 	@MockBean
 	protected CookieProperties cookieProperties;
+
+	@MockBean
+	protected FrontendProperties frontendProperties;
 	// Jwt
 	@MockBean
 	protected LoginUserArgumentResolver loginUserArgumentResolver;
@@ -146,6 +150,15 @@ public abstract class ControllerTest {
 		given(cookieProperties.path()).willReturn("/");
 		given(cookieProperties.sameSite()).willReturn("none");
 		given(cookieProperties.maxAge()).willReturn(Duration.ofDays(7));
+		given(frontendProperties.corsAllowedOrigins()).willReturn(
+			java.util.List.of("https://www.moddo.kr", "http://localhost:3000", "http://localhost:4173")
+		);
+		given(frontendProperties.redirectAllowedOrigins()).willReturn(
+			java.util.List.of("http://localhost:3000", "https://moddo-frontend.pages.dev", "https://www.moddo.kr",
+				"https://moddo.kr")
+		);
+		given(frontendProperties.defaultLocalRedirectUrl()).willReturn("http://localhost:3000");
+		given(frontendProperties.defaultProdRedirectUrl()).willReturn("https://www.moddo.kr");
 	}
 
 	protected String toJson(Object object) throws JsonProcessingException {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -41,7 +41,7 @@ aws:
 
 cookie:
   secure: true
-  http-only: false
+  http-only: true
   path: /
   same-site: none
   max-age: 7D


### PR DESCRIPTION
### #️⃣연관된 이슈
 X

### 🔀반영 브랜치
 fix/login -> develop

### 🔧변경 사항

- 인증 쿠키 설정을 `HttpOnly=true` 기반으로 정리하고, 게스트 토큰 발급/카카오 로그인/토큰 재발급 응답이 쿠키를 통해 토큰을 전달하도록 수정했습니다.
- `AuthCookieManager`를 추가해 쿠키 생성/만료 로직을 분리했습니다.
- `AuthRedirectResolver`를 추가해 카카오 로그인 callback의 `state` URL을 검증하고, 허용되지 않은 origin은 로컬/운영 환경에 맞는 기본 URL로 fallback 하도록 처리했습니다.
- `RefreshTokenService`가 refresh token에서 `AUTH_ID`를 기준으로 사용자를 조회하도록 보완했습니다. 
- 인증 관련 REST Docs 및 컨트롤러 테스트를 현재 동작에 맞게 수정했습니다.
- `RefreshTokenService`의 누락 분기와 `AuthCookieManager`, `AuthRedirectResolver`에 대한 테스트 코드를 추가했습니다.

### 💬리뷰 요구사항(선택)
X

### 체크

- [x] 테스트 코드 포함 여부
- [x] 불필요한 로그 제거
- [x] 예외 처리 여부


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증 토큰이 HttpOnly 쿠키를 통해 전달되어 보안이 강화되었습니다.
  * 토큰 재발급 시 쿠키 기반 방식으로 변경되었습니다.
  * OAuth 로그인 리다이렉트 시 출처 검증이 추가되었습니다.

* **버그 수정**
  * HttpOnly 쿠키 설정이 활성화되어 XSS 공격으로부터 보호됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->