### PR TITLE
fix: state 기반 카카오 redirect uri 분기 처리

### DIFF
--- a/src/main/java/com/dnd/moddo/auth/application/AuthService.java
+++ b/src/main/java/com/dnd/moddo/auth/application/AuthService.java
@@ -42,8 +42,8 @@ public class AuthService {
 	}
 
 	@Transactional
-	public TokenResponse loginOrRegisterWithKakao(String code) {
-		KakaoTokenResponse tokenResponse = kakaoClient.join(code);
+	public TokenResponse loginOrRegisterWithKakao(String code, String state) {
+		KakaoTokenResponse tokenResponse = kakaoClient.join(code, state);
 		KakaoProfile kakaoProfile = kakaoClient.getKakaoProfile(tokenResponse.accessToken());
 
 		String email = kakaoProfile.kakaoAccount().email();

--- a/src/main/java/com/dnd/moddo/auth/application/KakaoClient.java
+++ b/src/main/java/com/dnd/moddo/auth/application/KakaoClient.java
@@ -1,5 +1,7 @@
 package com.dnd.moddo.auth.application;
 
+import java.net.URI;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -28,13 +30,14 @@ public class KakaoClient {
 		this.restClient = builder.build();
 	}
 
-	public KakaoTokenResponse join(String code) {
+	public KakaoTokenResponse join(String code, String state) {
 		String uri = kakaoProperties.tokenRequestUri();
+		String redirectUri = resolveRedirectUri(state);
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("grant_type", "authorization_code");
 		params.add("client_id", kakaoProperties.clientId());
-		params.add("redirect_uri", kakaoProperties.redirectUri());
+		params.add("redirect_uri", redirectUri);
 		params.add("code", code);
 
 		try {
@@ -53,6 +56,33 @@ public class KakaoClient {
 			log.info("[USER_LOGIN_FAIL] 로그인 실패 : code = {}", code);
 			throw new IllegalArgumentException(e.getMessage());
 		}
+	}
+
+	private String resolveRedirectUri(String state) {
+		try {
+			URI stateUri = URI.create(state);
+			URI localRedirectUri = URI.create(kakaoProperties.localRedirectUri());
+
+			if (isSameOrigin(stateUri, localRedirectUri)) {
+				return kakaoProperties.localRedirectUri();
+			}
+		} catch (IllegalArgumentException e) {
+			log.warn("[KAKAO_LOGIN] state 파싱 실패, 기본 redirectUri 사용: state={}", state);
+		}
+
+		return kakaoProperties.redirectUri();
+	}
+
+	private boolean isSameOrigin(URI sourceUri, URI targetUri) {
+		return sourceUri.isAbsolute()
+			&& targetUri.isAbsolute()
+			&& sourceUri.getScheme() != null
+			&& targetUri.getScheme() != null
+			&& sourceUri.getHost() != null
+			&& targetUri.getHost() != null
+			&& sourceUri.getScheme().equalsIgnoreCase(targetUri.getScheme())
+			&& sourceUri.getHost().equalsIgnoreCase(targetUri.getHost())
+			&& sourceUri.getPort() == targetUri.getPort();
 	}
 
 	public KakaoProfile getKakaoProfile(String token) {

--- a/src/main/java/com/dnd/moddo/auth/application/KakaoClient.java
+++ b/src/main/java/com/dnd/moddo/auth/application/KakaoClient.java
@@ -59,12 +59,17 @@ public class KakaoClient {
 	}
 
 	private String resolveRedirectUri(String state) {
+		String localRedirectUri = kakaoProperties.localRedirectUri();
+		if (state == null || localRedirectUri == null) {
+			return kakaoProperties.redirectUri();
+		}
+
 		try {
 			URI stateUri = URI.create(state);
-			URI localRedirectUri = URI.create(kakaoProperties.localRedirectUri());
+			URI localUri = URI.create(localRedirectUri);
 
-			if (isSameOrigin(stateUri, localRedirectUri)) {
-				return kakaoProperties.localRedirectUri();
+			if (isSameOrigin(stateUri, localUri)) {
+				return localRedirectUri;
 			}
 		} catch (IllegalArgumentException e) {
 			log.warn("[KAKAO_LOGIN] state 파싱 실패, 기본 redirectUri 사용: state={}", state);

--- a/src/main/java/com/dnd/moddo/auth/presentation/AuthController.java
+++ b/src/main/java/com/dnd/moddo/auth/presentation/AuthController.java
@@ -73,7 +73,7 @@ public class AuthController {
 		@RequestParam @NotBlank String state,
 		HttpServletRequest request) {
 
-		TokenResponse tokenResponse = authService.loginOrRegisterWithKakao(code);
+		TokenResponse tokenResponse = authService.loginOrRegisterWithKakao(code, state);
 		String redirectUrl = authRedirectResolver.resolve(state, request);
 
 		String accessTokenCookie = authCookieManager.createCookie("accessToken", tokenResponse.accessToken());

--- a/src/main/java/com/dnd/moddo/common/config/KakaoProperties.java
+++ b/src/main/java/com/dnd/moddo/common/config/KakaoProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "kakao")
 public record KakaoProperties(
 	String redirectUri,
+	String localRedirectUri,
 	String clientId,
 	String adminKey,
 	String tokenRequestUri,

--- a/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.payload.JsonFieldType;
 
-import com.dnd.moddo.auth.presentation.response.KakaoTokenResponse;
 import com.dnd.moddo.auth.presentation.response.LoginUserInfo;
 import com.dnd.moddo.auth.presentation.response.RefreshResponse;
 import com.dnd.moddo.auth.presentation.response.TokenResponse;
@@ -87,12 +86,9 @@ class AuthControllerTest extends RestDocsTestSupport {
 	@DisplayName("카카오에서 인가코드를 통해 토큰을 발급받아 사용자 정보를 가져와 등록시킨 뒤 엑세스 토큰을 발급하여 쿠키로 전달한다.")
 	void kakaoLoginCallback() throws Exception {
 		//given
-		KakaoTokenResponse kakaoTokenResponse = new KakaoTokenResponse("kakao-access-token", 3600);
-		given(kakaoClient.join(anyString())).willReturn(kakaoTokenResponse);
-
 		TokenResponse tokenResponse = new TokenResponse("access-token", "refresh-token",
 			ZonedDateTime.now().plusMonths(1), true);
-		given(authService.loginOrRegisterWithKakao(anyString())).willReturn(tokenResponse);
+		given(authService.loginOrRegisterWithKakao(anyString(), anyString())).willReturn(tokenResponse);
 
 		//when & then
 		mockMvc.perform(get("/api/v1/login/oauth2/callback")
@@ -125,7 +121,7 @@ class AuthControllerTest extends RestDocsTestSupport {
 		// given
 		TokenResponse tokenResponse = new TokenResponse("access-token", "refresh-token",
 			ZonedDateTime.now().plusMonths(1), true);
-		given(authService.loginOrRegisterWithKakao(anyString())).willReturn(tokenResponse);
+		given(authService.loginOrRegisterWithKakao(anyString(), anyString())).willReturn(tokenResponse);
 
 		// when & then
 		mockMvc.perform(get("/api/v1/login/oauth2/callback")
@@ -148,7 +144,7 @@ class AuthControllerTest extends RestDocsTestSupport {
 		// given
 		TokenResponse tokenResponse = new TokenResponse("access-token", "refresh-token",
 			ZonedDateTime.now().plusMonths(1), true);
-		given(authService.loginOrRegisterWithKakao(anyString())).willReturn(tokenResponse);
+		given(authService.loginOrRegisterWithKakao(anyString(), anyString())).willReturn(tokenResponse);
 
 		// when & then
 		mockMvc.perform(get("/api/v1/login/oauth2/callback")

--- a/src/test/java/com/dnd/moddo/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/AuthServiceTest.java
@@ -55,6 +55,7 @@ public class AuthServiceTest {
 	void whenKakaoUserExists_thenTokenIsIssued() {
 		//given
 		String token = "test_token";
+		String state = "https://www.moddo.kr/login/callback";
 		KakaoProfile kakaoProfile = new KakaoProfile(
 			12345L,
 			new KakaoProfile.KakaoAccount(
@@ -71,12 +72,12 @@ public class AuthServiceTest {
 		String email = kakaoProfile.kakaoAccount().email();
 		User user = createWithEmail(email);
 
-		when(kakaoClient.join(anyString())).thenReturn(kakaoTokenResponse);
+		when(kakaoClient.join(anyString(), anyString())).thenReturn(kakaoTokenResponse);
 		when(kakaoClient.getKakaoProfile(anyString())).thenReturn(kakaoProfile);
 		when(commandUserService.getOrCreateUser(any())).thenReturn(user);
 
 		//when
-		TokenResponse response = authService.loginOrRegisterWithKakao(token);
+		TokenResponse response = authService.loginOrRegisterWithKakao(token, state);
 
 		//then
 		verify(jwtProvider, times(1)).generateToken(any());

--- a/src/test/java/com/dnd/moddo/domain/auth/service/KakaoClientTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/KakaoClientTest.java
@@ -43,6 +43,7 @@ public class KakaoClientTest {
 	void whenRequestKakaoAccessToken_thenReturnOauthToken() throws Exception {
 		// given
 		String code = "test_code";
+		String state = "https://www.moddo.kr/login/callback";
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("code", "test_code");
@@ -63,7 +64,7 @@ public class KakaoClientTest {
 			.andExpect(content().formData(params))
 			.andRespond(withSuccess(expectResponse, MediaType.APPLICATION_JSON));
 		// when
-		KakaoTokenResponse result = kakaoClient.join("test_code");
+		KakaoTokenResponse result = kakaoClient.join(code, state);
 
 		// then
 		assertThat(result).isNotNull();
@@ -75,6 +76,7 @@ public class KakaoClientTest {
 	void whenRequestKakaoAccessTokenWithInvalidCode_thenThrowException() {
 		//given
 		String code = "invalid_code";
+		String state = "https://www.moddo.kr/login/callback";
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("grant_type", "authorization_code");
@@ -89,9 +91,42 @@ public class KakaoClientTest {
 			.andRespond(withStatus(HttpStatus.BAD_REQUEST));
 
 		//when & then
-		assertThatThrownBy(() -> kakaoClient.join(code))
+		assertThatThrownBy(() -> kakaoClient.join(code, state))
 			.isInstanceOf(ModdoException.class)
 			.hasMessageContaining("카카오 API HTTP 에러");
+	}
+
+	@DisplayName("로컬 state origin이면 로컬 redirect_uri로 토큰을 요청한다")
+	@Test
+	void whenRequestKakaoAccessTokenWithLocalState_thenUseLocalRedirectUri() {
+		// given
+		String code = "test_code";
+		String state = "http://localhost:3000/login/callback?next=%2Fhome";
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", kakaoProperties.clientId());
+		params.add("redirect_uri", kakaoProperties.localRedirectUri());
+		params.add("code", code);
+
+		String expectResponse = """
+			{
+			  "access_token": "test_token",
+			  "expires_in": 3600
+			}
+			""";
+
+		mockServer.expect(requestTo(kakaoProperties.tokenRequestUri()))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"))
+			.andExpect(content().formData(params))
+			.andRespond(withSuccess(expectResponse, MediaType.APPLICATION_JSON));
+
+		// when
+		KakaoTokenResponse result = kakaoClient.join(code, state);
+
+		// then
+		assertThat(result.accessToken()).isEqualTo("test_token");
 	}
 
 	@DisplayName("정상 토큰으로 카카오 프로필 요청 시 KakaoProfile이 반환된다")

--- a/src/test/java/com/dnd/moddo/domain/auth/service/KakaoClientTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/KakaoClientTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -127,6 +128,54 @@ public class KakaoClientTest {
 
 		// then
 		assertThat(result.accessToken()).isEqualTo("test_token");
+	}
+
+	@DisplayName("localRedirectUri가 없으면 기본 redirect_uri로 토큰을 요청한다")
+	@Test
+	void whenLocalRedirectUriIsNull_thenUseDefaultRedirectUri() {
+		// given
+		String code = "test_code";
+		String state = "http://localhost:3000/login/callback?next=%2Fhome";
+		KakaoProperties nullLocalRedirectProperties = new KakaoProperties(
+			kakaoProperties.redirectUri(),
+			null,
+			kakaoProperties.clientId(),
+			kakaoProperties.adminKey(),
+			kakaoProperties.tokenRequestUri(),
+			kakaoProperties.profileRequestUri(),
+			kakaoProperties.logoutRequestUri(),
+			kakaoProperties.unlinkRequestUri()
+		);
+
+		ReflectionTestUtils.setField(kakaoClient, "kakaoProperties", nullLocalRedirectProperties);
+		try {
+			MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+			params.add("grant_type", "authorization_code");
+			params.add("client_id", kakaoProperties.clientId());
+			params.add("redirect_uri", kakaoProperties.redirectUri());
+			params.add("code", code);
+
+			String expectResponse = """
+				{
+				  "access_token": "test_token",
+				  "expires_in": 3600
+				}
+				""";
+
+			mockServer.expect(requestTo(kakaoProperties.tokenRequestUri()))
+				.andExpect(method(HttpMethod.POST))
+				.andExpect(header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"))
+				.andExpect(content().formData(params))
+				.andRespond(withSuccess(expectResponse, MediaType.APPLICATION_JSON));
+
+			// when
+			KakaoTokenResponse result = kakaoClient.join(code, state);
+
+			// then
+			assertThat(result.accessToken()).isEqualTo("test_token");
+		} finally {
+			ReflectionTestUtils.setField(kakaoClient, "kakaoProperties", kakaoProperties);
+		}
 	}
 
 	@DisplayName("정상 토큰으로 카카오 프로필 요청 시 KakaoProfile이 반환된다")

--- a/src/test/java/com/dnd/moddo/domain/auth/service/implementation/AuthServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/implementation/AuthServiceTest.java
@@ -72,6 +72,7 @@ public class AuthServiceTest {
 	void loginOrRegisterWithKakao_success() {
 		// given
 		String code = "kakao_code";
+		String state = "https://www.moddo.kr/login/callback";
 		KakaoTokenResponse kakaoToken = new KakaoTokenResponse("kakao_access", 3600);
 		KakaoProfile kakaoProfile = new KakaoProfile(
 			12345L,
@@ -81,17 +82,17 @@ public class AuthServiceTest {
 		User user = createWithEmail("test@kakao.com");
 		TokenResponse tokenResponse = new TokenResponse("access", "refresh", ZonedDateTime.now(), true);
 
-		when(kakaoClient.join(code)).thenReturn(kakaoToken);
+		when(kakaoClient.join(code, state)).thenReturn(kakaoToken);
 		when(kakaoClient.getKakaoProfile(kakaoToken.accessToken())).thenReturn(kakaoProfile);
 		when(commandUserService.getOrCreateUser(any(UserSaveRequest.class))).thenReturn(user);
 		when(jwtProvider.generateToken(user)).thenReturn(tokenResponse);
 
 		// when
-		TokenResponse result = authService.loginOrRegisterWithKakao(code);
+		TokenResponse result = authService.loginOrRegisterWithKakao(code, state);
 
 		// then
 		assertThat(result).isEqualTo(tokenResponse);
-		verify(kakaoClient).join(code);
+		verify(kakaoClient).join(code, state);
 		verify(kakaoClient).getKakaoProfile(kakaoToken.accessToken());
 		verify(commandUserService).getOrCreateUser(any(UserSaveRequest.class));
 		verify(jwtProvider).generateToken(user);
@@ -102,6 +103,7 @@ public class AuthServiceTest {
 	void loginOrRegisterWithKakao_fail_profileMissing() {
 		// given
 		String code = "kakao_code";
+		String state = "https://www.moddo.kr/login/callback";
 		KakaoTokenResponse kakaoToken = new KakaoTokenResponse("kakao_access", 3600);
 		// kakaoAccount가 null인 경우 NPE가 먼저 발생하므로, email, nickname, kakaoId 중 하나가 null인 상황을 테스트해야 함
 		KakaoProfile kakaoProfile = new KakaoProfile(
@@ -110,11 +112,11 @@ public class AuthServiceTest {
 			new KakaoProfile.Properties(null)
 		);
 
-		when(kakaoClient.join(code)).thenReturn(kakaoToken);
+		when(kakaoClient.join(code, state)).thenReturn(kakaoToken);
 		when(kakaoClient.getKakaoProfile(kakaoToken.accessToken())).thenReturn(kakaoProfile);
 
 		// when & then
-		assertThatThrownBy(() -> authService.loginOrRegisterWithKakao(code))
+		assertThatThrownBy(() -> authService.loginOrRegisterWithKakao(code, state))
 			.isInstanceOf(ModdoException.class)
 			.hasFieldOrPropertyWithValue("status", HttpStatus.BAD_REQUEST);
 	}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -51,6 +51,7 @@ kakao:
   client-id: clientidclientidclientidclientidclientidclientidclientid
   admin-key: adminkeyadminkeyadminkeyadminkeyadminkey
   redirect-uri: http://localhost:8080/api/v1/login/kakao/callback
+  local-redirect-uri: http://localhost:3000/api/v1/login/oauth2/callback
   token-request-uri: https://kauth.kakao.com/oauth/token
   profile-request-uri: https://kapi.kakao.com/v2/user/me
   logout-request-uri: https://kapi.kakao.com/v1/user/logout


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
fix/login -> develop

### 🔧변경 사항
- state에 담긴 프론트 리다이렉트 URL의 origin을 기준으로 카카오 토큰 요청용 redirect_uri를 분기하도록 수정했습니다.
- 로컬 프론트에서 카카오 소셜 로그인 테스트 시, 카카오 콜백을 프론트가 먼저 받은 뒤 프록시로 백엔드 콜백 API를 호출하는 흐름에서도 redirect_uri mismatch가 발생하지 않도록 대응했습니다.
  - 로컬 테스트에서 이런 흐름이 필요한 이유는 소셜 로그인 콜백을 로컬 프론트에서 직접 받고, 이후 백엔드로 code를 전달해 쿠키 기반 로그인 처리를 이어가기 위해서입니다.
  - 운영 흐름은 기존 redirect URI를 유지하고, 로컬 프론트 origin인 경우에만 로컬 콜백 URI를 사용하도록 처리했습니다.
- 관련 인증 로직 테스트를 함께 수정하고 검증했습니다.

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * Kakao OAuth 인증 흐름에서 상태 파라미터 처리를 강화했습니다.
  * 환경별 리다이렉트 URI 설정을 개선하여 로컬 개발과 프로덕션 환경을 구분하여 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->