### PR TITLE
feat: cors 프론트엔드 개발 서버 도메인 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/common/config/WebConfig.java
+++ b/src/main/java/com/dnd/moddo/common/config/WebConfig.java
@@ -19,8 +19,17 @@ public class WebConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
+		List<String> corsAllowedOrigins = frontendProperties.corsAllowedOrigins();
+		String[] allowedOrigins = corsAllowedOrigins.stream()
+			.filter(origin -> !origin.contains("*"))
+			.toArray(String[]::new);
+		String[] allowedOriginPatterns = corsAllowedOrigins.stream()
+			.filter(origin -> origin.contains("*"))
+			.toArray(String[]::new);
+
 		registry.addMapping("/**")
-			.allowedOriginPatterns(frontendProperties.corsAllowedOrigins().toArray(String[]::new))
+			.allowedOrigins(allowedOrigins)
+			.allowedOriginPatterns(allowedOriginPatterns)
 			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
 			.allowedHeaders("*")
 			.exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials")

--- a/src/main/java/com/dnd/moddo/common/config/WebConfig.java
+++ b/src/main/java/com/dnd/moddo/common/config/WebConfig.java
@@ -20,7 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins(frontendProperties.corsAllowedOrigins().toArray(String[]::new))
+			.allowedOriginPatterns(frontendProperties.corsAllowedOrigins().toArray(String[]::new))
 			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
 			.allowedHeaders("*")
 			.exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,8 @@ cookie:
 frontend:
   cors-allowed-origins:
     - https://www.moddo.kr
+    - https://moddo-frontend.pages.dev
+    - https://*.moddo-frontend.pages.dev
     - http://localhost:3000
     - http://localhost:4173
   redirect-allowed-origins:
@@ -71,7 +73,6 @@ spring:
       on-profile: prod
 
 ---
-
 
 
 

--- a/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
+++ b/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
@@ -151,8 +151,7 @@ public abstract class ControllerTest {
 		given(cookieProperties.sameSite()).willReturn("none");
 		given(cookieProperties.maxAge()).willReturn(Duration.ofDays(7));
 		given(frontendProperties.corsAllowedOrigins()).willReturn(
-			java.util.List.of("https://www.moddo.kr", "https://moddo-frontend.pages.dev",
-				"https://*.moddo-frontend.pages.dev", "http://localhost:3000", "http://localhost:4173")
+			java.util.List.of("https://www.moddo.kr", "http://localhost:3000", "http://localhost:4173")
 		);
 		given(frontendProperties.redirectAllowedOrigins()).willReturn(
 			java.util.List.of("http://localhost:3000", "https://moddo-frontend.pages.dev", "https://www.moddo.kr",

--- a/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
+++ b/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
@@ -151,7 +151,8 @@ public abstract class ControllerTest {
 		given(cookieProperties.sameSite()).willReturn("none");
 		given(cookieProperties.maxAge()).willReturn(Duration.ofDays(7));
 		given(frontendProperties.corsAllowedOrigins()).willReturn(
-			java.util.List.of("https://www.moddo.kr", "http://localhost:3000", "http://localhost:4173")
+			java.util.List.of("https://www.moddo.kr", "https://moddo-frontend.pages.dev",
+				"https://*.moddo-frontend.pages.dev", "http://localhost:3000", "http://localhost:4173")
 		);
 		given(frontendProperties.redirectAllowedOrigins()).willReturn(
 			java.util.List.of("http://localhost:3000", "https://moddo-frontend.pages.dev", "https://www.moddo.kr",


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
`fix/login -> develop`

### 🔧변경 사항
- CORS 허용 origin 목록에 `https://moddo-frontend.pages.dev`를 추가했습니다.
- Cloudflare Pages preview 도메인 대응을 위해 `https://*.moddo-frontend.pages.dev`를 추가했습니다.
- 와일드카드 origin이 동작하도록 Spring CORS 설정을 `allowedOriginPatterns` 기반으로 변경했습니다.
- Controller 테스트 공통 설정의 CORS mock 목록을 실제 설정과 맞췄습니다.

### 💬리뷰 요구사항(선택)
X

### 체크
- [x] 테스트 코드 포함 여부
- [x] 불필요한 로그 제거
- [x] 예외 처리 여부

검증: `./gradlew compileJava`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CORS 설정 방식을 패턴 기반 매칭으로 업데이트했습니다.
  * 새로운 프론트엔드 도메인(moddo-frontend.pages.dev 및 관련 서브도메인)을 CORS 허용 목록에 추가했습니다.

* **Tests**
  * 새로운 출처에 대한 테스트 커버리지를 확대했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->