### PR TITLE
(fix) : 루트 moddo 도메인 CORS 허용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,7 @@ cookie:
 frontend:
   cors-allowed-origins:
     - https://www.moddo.kr
+    - https://moddo.kr
     - https://moddo-frontend.pages.dev
     - https://*.moddo-frontend.pages.dev
     - http://localhost:3000


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
fix/login -> develop

### 🔧변경 사항
- 프론트엔드 CORS 허용 origin에 `https://moddo.kr`를 추가했습니다.
- `www.moddo.kr`가 아닌 루트 도메인 접속에서도 백엔드 API 요청이 허용되도록 설정했습니다.

### 💬리뷰 요구사항(선택)
X

---

### 체크
- 테스트 코드 포함 여부: 설정 변경만 있어 별도 테스트 코드는 추가하지 않았습니다.
- 불필요한 로그 제거: 해당 없음
- 예외 처리 여부: 해당 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기타**
  * 새로운 도메인(`https://moddo.kr`)에서의 서비스 접근을 지원하도록 CORS 설정을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->