### PR TITLE
(fix) : 토큰 만료 응답과 정산 응답 정보 수정

### DIFF
--- a/src/main/java/com/dnd/moddo/event/application/impl/SettlementReader.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/SettlementReader.java
@@ -44,7 +44,9 @@ public class SettlementReader {
 
 		return SettlementHeaderResponse.of(settlement.getName(), totalAmount, settlement.getDeadline(),
 			settlement.getBank(),
-			settlement.getAccountNumber());
+			settlement.getAccountNumber(),
+			settlement.getCreatedAt(),
+			settlement.getCompletedAt());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/dnd/moddo/event/presentation/response/SettlementHeaderResponse.java
+++ b/src/main/java/com/dnd/moddo/event/presentation/response/SettlementHeaderResponse.java
@@ -7,10 +7,13 @@ public record SettlementHeaderResponse(
 	Long totalAmount,
 	LocalDateTime deadline,
 	String bank,
-	String accountNumber
+	String accountNumber,
+	LocalDateTime createdAt,
+	LocalDateTime completedAt
 ) {
 	public static SettlementHeaderResponse of(String groupName, Long totalAmount, LocalDateTime deadline, String bank,
-		String accountNumber) {
-		return new SettlementHeaderResponse(groupName, totalAmount, deadline, bank, accountNumber);
+		String accountNumber, LocalDateTime createdAt, LocalDateTime completedAt) {
+		return new SettlementHeaderResponse(groupName, totalAmount, deadline, bank, accountNumber, createdAt,
+			completedAt);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
@@ -121,7 +121,7 @@ public class SettlementControllerTest extends RestDocsTestSupport {
 		// given
 		SettlementHeaderResponse response = SettlementHeaderResponse.of("모또 모임", 10000L,
 			LocalDateTime.now().plusDays(1), "우리은행",
-			"1111-1111");
+			"1111-1111", LocalDateTime.now(), null);
 
 		given(querySettlementService.findIdByCode("code")).willReturn(100L);
 		given(querySettlementService.findBySettlementHeader(100L)).willReturn(response);

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/QuerySettlementServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/QuerySettlementServiceTest.java
@@ -123,7 +123,8 @@ class QuerySettlementServiceTest {
 	void FindBySettlementHeader_Success() {
 		// Given
 		SettlementHeaderResponse expectedResponse = new SettlementHeaderResponse(settlement.getName(), 1000L,
-			LocalDateTime.now().plusDays(1), settlement.getBank(), settlement.getAccountNumber());
+			LocalDateTime.now().plusDays(1), settlement.getBank(), settlement.getAccountNumber(),
+			settlement.getCreatedAt(), settlement.getCompletedAt());
 		when(cacheExecutor.execute(anyString(), any(), any())).thenReturn(expectedResponse);
 
 		// When

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementReaderTest.java
@@ -95,6 +95,8 @@ class SettlementReaderTest {
 		when(mockSettlement.getName()).thenReturn("모임 이름");
 		when(mockSettlement.getBank()).thenReturn("은행");
 		when(mockSettlement.getAccountNumber()).thenReturn("1234-1234");
+		when(mockSettlement.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 5, 10, 12, 0));
+		when(mockSettlement.getCompletedAt()).thenReturn(LocalDateTime.of(2026, 5, 11, 12, 0));
 		when(settlementRepository.getById(anyLong())).thenReturn(mockSettlement);
 
 		Long totalAmount = 1000L;
@@ -109,6 +111,8 @@ class SettlementReaderTest {
 		assertThat(result.totalAmount()).isEqualTo(1000L);
 		assertThat(result.bank()).isEqualTo("은행");
 		assertThat(result.accountNumber()).isEqualTo("1234-1234");
+		assertThat(result.createdAt()).isEqualTo(LocalDateTime.of(2026, 5, 10, 12, 0));
+		assertThat(result.completedAt()).isEqualTo(LocalDateTime.of(2026, 5, 11, 12, 0));
 		verify(settlementRepository, times(1)).getById(groupId);
 		verify(expenseRepository, times(1)).sumAmountBySettlement(mockSettlement);
 	}


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
fix/member-count -> develop

### 🔧변경 사항
- 정산 헤더 응답에 `createdAt`, `completedAt` 필드를 추가했습니다.
- 정산 헤더 조회 시 정산 생성일과 완료일을 함께 내려주도록 수정했습니다.
- 관련 서비스/컨트롤러 테스트 데이터를 새 응답 스펙에 맞게 갱신했습니다.
- 만료된 JWT가 들어온 경우 `401`과 `토큰이 만료되었습니다.` 메시지를 JSON으로 내려주도록 수정했습니다.
- 정산 목록 조회에서 내 멤버 row와 전체 참여자 집계용 멤버 row를 분리해 `totalMemberCount`, 완료 인원 집계가 전체 정산 멤버 기준으로 계산되도록 수정했습니다.

### 💬리뷰 요구사항(선택)
X

### ✅체크
- 테스트 코드 포함 여부: 포함
- 불필요한 로그 제거: 해당 없음
- 예외 처리 여부: 기존 흐름 유지

### 🧪검증
- `./gradlew --no-daemon test --tests com.dnd.moddo.domain.settlement.service.implementation.SettlementReaderTest --tests com.dnd.moddo.domain.settlement.service.QuerySettlementServiceTest --tests com.dnd.moddo.domain.settlement.controller.SettlementControllerTest`
- `./gradlew --no-daemon test --tests com.dnd.moddo.domain.auth.service.JwtFilterTest --tests com.dnd.moddo.domain.settlement.controller.SettlementControllerTest`
