### PR TITLE
(fix) : 토큰 만료 응답과 정산 멤버 수 조회 수정

### DIFF
--- a/src/main/java/com/dnd/moddo/auth/infrastructure/security/JwtFilter.java
+++ b/src/main/java/com/dnd/moddo/auth/infrastructure/security/JwtFilter.java
@@ -2,11 +2,19 @@ package com.dnd.moddo.auth.infrastructure.security;
 
 import java.io.IOException;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.dnd.moddo.common.exception.ErrorResponse;
+import com.dnd.moddo.common.exception.ModdoException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,6 +27,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
 	private final JwtAuth jwtAuth;
 	private final JwtUtil jwtUtil;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -26,12 +35,33 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		String token = jwtUtil.resolveToken(request);
 
-		if (token != null) {
-			Authentication authentication = jwtAuth.getAuthentication(token, JwtConstants.ACCESS_KEY.message);
-			SecurityContextHolder.getContext().setAuthentication(authentication);
+		try {
+			if (token != null) {
+				Authentication authentication = jwtAuth.getAuthentication(token, JwtConstants.ACCESS_KEY.message);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		} catch (ExpiredJwtException e) {
+			SecurityContextHolder.clearContext();
+			writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
+			return;
+		} catch (JwtException e) {
+			SecurityContextHolder.clearContext();
+			writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다.");
+			return;
+		} catch (ModdoException e) {
+			SecurityContextHolder.clearContext();
+			writeErrorResponse(response, e.getStatus(), e.getMessage());
+			return;
 		}
 
 		filterChain.doFilter(request, response);
+	}
+
+	private void writeErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+		response.setStatus(status.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+		objectMapper.writeValue(response.getWriter(), new ErrorResponse(status.value(), message));
 	}
 
 	@Override

--- a/src/main/java/com/dnd/moddo/common/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/moddo/common/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.web.cors.CorsUtils;
 import com.dnd.moddo.auth.infrastructure.security.JwtAuth;
 import com.dnd.moddo.auth.infrastructure.security.JwtFilter;
 import com.dnd.moddo.auth.infrastructure.security.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +26,7 @@ public class SecurityConfig {
 
 	private final JwtUtil jwtUtil;
 	private final JwtAuth jwtAuth;
+	private final ObjectMapper objectMapper;
 
 	@Bean
 	public BCryptPasswordEncoder passwordEncoder() {
@@ -43,7 +45,7 @@ public class SecurityConfig {
 				.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
 				.anyRequest().permitAll()
 			)
-			.addFilterBefore(new JwtFilter(jwtAuth, jwtUtil), UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(new JwtFilter(jwtAuth, jwtUtil, objectMapper), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/com/dnd/moddo/event/infrastructure/SettlementQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/moddo/event/infrastructure/SettlementQueryRepositoryImpl.java
@@ -37,11 +37,12 @@ public class SettlementQueryRepositoryImpl
 		int limit
 	) {
 		QSettlement settlement = QSettlement.settlement;
-		QMember member = QMember.member;
+		QMember myMember = new QMember("myMember");
+		QMember settlementMember = new QMember("settlementMember");
 		QExpense expense = QExpense.expense;
 
 		BooleanExpression userCondition =
-			member.user.id.eq(userId);
+			myMember.user.id.eq(userId);
 
 		BooleanExpression statusCondition = null;
 
@@ -56,13 +57,13 @@ public class SettlementQueryRepositoryImpl
 				? userCondition.and(statusCondition)
 				: userCondition;
 
-		NumberExpression<Long> memberCount = member.id.count();
+		NumberExpression<Long> memberCount = settlementMember.id.count();
 
 		NumberExpression<Long> completedCount =
 			Expressions.numberTemplate(
 				Long.class,
 				"sum(case when {0} = true then 1 else 0 end)",
-				member.isPaid
+				settlementMember.isPaid
 			);
 
 		JPQLQuery<Long> totalAmount =
@@ -86,8 +87,9 @@ public class SettlementQueryRepositoryImpl
 				settlement.createdAt,
 				settlement.completedAt
 			))
-			.from(member)
-			.join(member.settlement, settlement)
+			.from(myMember)
+			.join(myMember.settlement, settlement)
+			.join(settlementMember).on(settlementMember.settlement.id.eq(settlement.id))
 			.where(finalCondition)
 			.groupBy(
 				settlement.id,

--- a/src/test/java/com/dnd/moddo/domain/auth/service/JwtFilterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/JwtFilterTest.java
@@ -1,0 +1,64 @@
+package com.dnd.moddo.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.dnd.moddo.auth.infrastructure.security.JwtAuth;
+import com.dnd.moddo.auth.infrastructure.security.JwtFilter;
+import com.dnd.moddo.auth.infrastructure.security.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+
+@ExtendWith(MockitoExtension.class)
+class JwtFilterTest {
+
+	@Mock
+	JwtAuth jwtAuth;
+
+	@Mock
+	JwtUtil jwtUtil;
+
+	@Mock
+	FilterChain filterChain;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void givenExpiredToken_thenReturnTokenExpiredResponse() throws Exception {
+		// given
+		String token = "expired-token";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		JwtFilter jwtFilter = new JwtFilter(jwtAuth, jwtUtil, objectMapper);
+
+		given(jwtUtil.resolveToken(any(MockHttpServletRequest.class))).willReturn(token);
+		given(jwtAuth.getAuthentication(token, "access_token"))
+			.willThrow(new ExpiredJwtException(null, null, "expired"));
+
+		// when
+		jwtFilter.doFilter(request, response, filterChain);
+
+		// then
+		assertThat(response.getStatus()).isEqualTo(401);
+		assertThat(response.getContentType()).startsWith("application/json");
+		assertThat(response.getContentAsString()).contains("\"message\":\"토큰이 만료되었습니다.\"");
+		then(filterChain).should(never()).doFilter(request, response);
+	}
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
fix/member-count -> develop

### 🔧변경 사항
- 만료된 JWT가 들어온 경우 `401`과 `토큰이 만료되었습니다.` 메시지를 JSON으로 내려주도록 수정했습니다.
- JWT 필터에서 인증 실패 시 SecurityContext를 정리하고 요청 체인을 중단하도록 처리했습니다.
- 정산 목록 조회에서 내 멤버 row와 전체 참여자 집계용 멤버 row를 분리했습니다.
- `totalMemberCount`, 완료 인원 집계가 현재 사용자 기준이 아니라 전체 정산 멤버 기준으로 계산되도록 수정했습니다.
- JWT 만료 응답 테스트를 추가했습니다.

### 💬리뷰 요구사항(선택)
X

### ✅체크
- 테스트 코드 포함 여부: 포함
- 불필요한 로그 제거: 해당 없음
- 예외 처리 여부: 포함

### 🧪검증
- `./gradlew --no-daemon test --tests com.dnd.moddo.domain.auth.service.JwtFilterTest --tests com.dnd.moddo.domain.settlement.controller.SettlementControllerTest`
