### PR TITLE
(fix) : 정산 및 인증 응답 수정사항 배포

### DIFF
--- a/src/main/java/com/dnd/moddo/auth/infrastructure/security/JwtFilter.java
+++ b/src/main/java/com/dnd/moddo/auth/infrastructure/security/JwtFilter.java
@@ -2,11 +2,19 @@ package com.dnd.moddo.auth.infrastructure.security;
 
 import java.io.IOException;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.dnd.moddo.common.exception.ErrorResponse;
+import com.dnd.moddo.common.exception.ModdoException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,6 +27,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
 	private final JwtAuth jwtAuth;
 	private final JwtUtil jwtUtil;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -26,12 +35,33 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		String token = jwtUtil.resolveToken(request);
 
-		if (token != null) {
-			Authentication authentication = jwtAuth.getAuthentication(token, JwtConstants.ACCESS_KEY.message);
-			SecurityContextHolder.getContext().setAuthentication(authentication);
+		try {
+			if (token != null) {
+				Authentication authentication = jwtAuth.getAuthentication(token, JwtConstants.ACCESS_KEY.message);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		} catch (ExpiredJwtException e) {
+			SecurityContextHolder.clearContext();
+			writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
+			return;
+		} catch (JwtException e) {
+			SecurityContextHolder.clearContext();
+			writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다.");
+			return;
+		} catch (ModdoException e) {
+			SecurityContextHolder.clearContext();
+			writeErrorResponse(response, e.getStatus(), e.getMessage());
+			return;
 		}
 
 		filterChain.doFilter(request, response);
+	}
+
+	private void writeErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+		response.setStatus(status.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+		objectMapper.writeValue(response.getWriter(), new ErrorResponse(status.value(), message));
 	}
 
 	@Override

--- a/src/main/java/com/dnd/moddo/common/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/moddo/common/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.web.cors.CorsUtils;
 import com.dnd.moddo.auth.infrastructure.security.JwtAuth;
 import com.dnd.moddo.auth.infrastructure.security.JwtFilter;
 import com.dnd.moddo.auth.infrastructure.security.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +26,7 @@ public class SecurityConfig {
 
 	private final JwtUtil jwtUtil;
 	private final JwtAuth jwtAuth;
+	private final ObjectMapper objectMapper;
 
 	@Bean
 	public BCryptPasswordEncoder passwordEncoder() {
@@ -43,7 +45,7 @@ public class SecurityConfig {
 				.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
 				.anyRequest().permitAll()
 			)
-			.addFilterBefore(new JwtFilter(jwtAuth, jwtUtil), UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(new JwtFilter(jwtAuth, jwtUtil, objectMapper), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/com/dnd/moddo/event/application/impl/SettlementReader.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/SettlementReader.java
@@ -44,7 +44,9 @@ public class SettlementReader {
 
 		return SettlementHeaderResponse.of(settlement.getName(), totalAmount, settlement.getDeadline(),
 			settlement.getBank(),
-			settlement.getAccountNumber());
+			settlement.getAccountNumber(),
+			settlement.getCreatedAt(),
+			settlement.getCompletedAt());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/dnd/moddo/event/infrastructure/SettlementQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/moddo/event/infrastructure/SettlementQueryRepositoryImpl.java
@@ -37,11 +37,12 @@ public class SettlementQueryRepositoryImpl
 		int limit
 	) {
 		QSettlement settlement = QSettlement.settlement;
-		QMember member = QMember.member;
+		QMember myMember = new QMember("myMember");
+		QMember settlementMember = new QMember("settlementMember");
 		QExpense expense = QExpense.expense;
 
 		BooleanExpression userCondition =
-			member.user.id.eq(userId);
+			myMember.user.id.eq(userId);
 
 		BooleanExpression statusCondition = null;
 
@@ -56,13 +57,13 @@ public class SettlementQueryRepositoryImpl
 				? userCondition.and(statusCondition)
 				: userCondition;
 
-		NumberExpression<Long> memberCount = member.id.count();
+		NumberExpression<Long> memberCount = settlementMember.id.count();
 
 		NumberExpression<Long> completedCount =
 			Expressions.numberTemplate(
 				Long.class,
 				"sum(case when {0} = true then 1 else 0 end)",
-				member.isPaid
+				settlementMember.isPaid
 			);
 
 		JPQLQuery<Long> totalAmount =
@@ -86,8 +87,9 @@ public class SettlementQueryRepositoryImpl
 				settlement.createdAt,
 				settlement.completedAt
 			))
-			.from(member)
-			.join(member.settlement, settlement)
+			.from(myMember)
+			.join(myMember.settlement, settlement)
+			.join(settlementMember).on(settlementMember.settlement.id.eq(settlement.id))
 			.where(finalCondition)
 			.groupBy(
 				settlement.id,

--- a/src/main/java/com/dnd/moddo/event/presentation/response/SettlementHeaderResponse.java
+++ b/src/main/java/com/dnd/moddo/event/presentation/response/SettlementHeaderResponse.java
@@ -7,10 +7,13 @@ public record SettlementHeaderResponse(
 	Long totalAmount,
 	LocalDateTime deadline,
 	String bank,
-	String accountNumber
+	String accountNumber,
+	LocalDateTime createdAt,
+	LocalDateTime completedAt
 ) {
 	public static SettlementHeaderResponse of(String groupName, Long totalAmount, LocalDateTime deadline, String bank,
-		String accountNumber) {
-		return new SettlementHeaderResponse(groupName, totalAmount, deadline, bank, accountNumber);
+		String accountNumber, LocalDateTime createdAt, LocalDateTime completedAt) {
+		return new SettlementHeaderResponse(groupName, totalAmount, deadline, bank, accountNumber, createdAt,
+			completedAt);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/auth/service/JwtFilterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/JwtFilterTest.java
@@ -1,0 +1,64 @@
+package com.dnd.moddo.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.dnd.moddo.auth.infrastructure.security.JwtAuth;
+import com.dnd.moddo.auth.infrastructure.security.JwtFilter;
+import com.dnd.moddo.auth.infrastructure.security.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+
+@ExtendWith(MockitoExtension.class)
+class JwtFilterTest {
+
+	@Mock
+	JwtAuth jwtAuth;
+
+	@Mock
+	JwtUtil jwtUtil;
+
+	@Mock
+	FilterChain filterChain;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void givenExpiredToken_thenReturnTokenExpiredResponse() throws Exception {
+		// given
+		String token = "expired-token";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		JwtFilter jwtFilter = new JwtFilter(jwtAuth, jwtUtil, objectMapper);
+
+		given(jwtUtil.resolveToken(any(MockHttpServletRequest.class))).willReturn(token);
+		given(jwtAuth.getAuthentication(token, "access_token"))
+			.willThrow(new ExpiredJwtException(null, null, "expired"));
+
+		// when
+		jwtFilter.doFilter(request, response, filterChain);
+
+		// then
+		assertThat(response.getStatus()).isEqualTo(401);
+		assertThat(response.getContentType()).startsWith("application/json");
+		assertThat(response.getContentAsString()).contains("\"message\":\"토큰이 만료되었습니다.\"");
+		then(filterChain).should(never()).doFilter(request, response);
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
@@ -121,7 +121,7 @@ public class SettlementControllerTest extends RestDocsTestSupport {
 		// given
 		SettlementHeaderResponse response = SettlementHeaderResponse.of("모또 모임", 10000L,
 			LocalDateTime.now().plusDays(1), "우리은행",
-			"1111-1111");
+			"1111-1111", LocalDateTime.now(), null);
 
 		given(querySettlementService.findIdByCode("code")).willReturn(100L);
 		given(querySettlementService.findBySettlementHeader(100L)).willReturn(response);

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/QuerySettlementServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/QuerySettlementServiceTest.java
@@ -123,7 +123,8 @@ class QuerySettlementServiceTest {
 	void FindBySettlementHeader_Success() {
 		// Given
 		SettlementHeaderResponse expectedResponse = new SettlementHeaderResponse(settlement.getName(), 1000L,
-			LocalDateTime.now().plusDays(1), settlement.getBank(), settlement.getAccountNumber());
+			LocalDateTime.now().plusDays(1), settlement.getBank(), settlement.getAccountNumber(),
+			settlement.getCreatedAt(), settlement.getCompletedAt());
 		when(cacheExecutor.execute(anyString(), any(), any())).thenReturn(expectedResponse);
 
 		// When

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementReaderTest.java
@@ -95,6 +95,8 @@ class SettlementReaderTest {
 		when(mockSettlement.getName()).thenReturn("모임 이름");
 		when(mockSettlement.getBank()).thenReturn("은행");
 		when(mockSettlement.getAccountNumber()).thenReturn("1234-1234");
+		when(mockSettlement.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 5, 10, 12, 0));
+		when(mockSettlement.getCompletedAt()).thenReturn(LocalDateTime.of(2026, 5, 11, 12, 0));
 		when(settlementRepository.getById(anyLong())).thenReturn(mockSettlement);
 
 		Long totalAmount = 1000L;
@@ -109,6 +111,8 @@ class SettlementReaderTest {
 		assertThat(result.totalAmount()).isEqualTo(1000L);
 		assertThat(result.bank()).isEqualTo("은행");
 		assertThat(result.accountNumber()).isEqualTo("1234-1234");
+		assertThat(result.createdAt()).isEqualTo(LocalDateTime.of(2026, 5, 10, 12, 0));
+		assertThat(result.completedAt()).isEqualTo(LocalDateTime.of(2026, 5, 11, 12, 0));
 		verify(settlementRepository, times(1)).getById(groupId);
 		verify(expenseRepository, times(1)).sumAmountBySettlement(mockSettlement);
 	}


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
develop -> main

### 🔧변경 사항
- 정산 헤더 응답에 생성일과 완료일 정보를 추가했습니다.
- 만료된 JWT 요청에 대해 명확한 401 JSON 응답을 반환하도록 수정했습니다.
- 정산 목록 조회의 전체 멤버 수와 완료 인원 집계를 전체 정산 멤버 기준으로 수정했습니다.

### 💬리뷰 요구사항(선택)
X

### ✅체크
- 테스트 코드 포함 여부: 포함
- 불필요한 로그 제거: 해당 없음
- 예외 처리 여부: 포함

### 🧪검증
- `./gradlew --no-daemon test --tests com.dnd.moddo.domain.settlement.service.implementation.SettlementReaderTest --tests com.dnd.moddo.domain.settlement.service.QuerySettlementServiceTest --tests com.dnd.moddo.domain.settlement.controller.SettlementControllerTest`
- `./gradlew --no-daemon test --tests com.dnd.moddo.domain.auth.service.JwtFilterTest --tests com.dnd.moddo.domain.settlement.controller.SettlementControllerTest`
