### PR TITLE
(fix) : 정산 상세 입금 확인 요청 ID 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestReader.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestReader.java
@@ -61,4 +61,14 @@ public class PaymentRequestReader {
 		return PaymentRequestsResponse.of(responses);
 	}
 
+	public Map<Long, Long> findPendingRequestIdByMemberId(Long settlementId) {
+		return paymentRequestRepository.findBySettlementIdAndStatus(settlementId, PaymentRequestStatus.PENDING)
+			.stream()
+			.collect(Collectors.toMap(
+				PaymentRequest::getRequestMemberId,
+				PaymentRequest::getId,
+				(first, ignored) -> first
+			));
+	}
+
 }

--- a/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestReader.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestReader.java
@@ -67,7 +67,9 @@ public class PaymentRequestReader {
 			.collect(Collectors.toMap(
 				PaymentRequest::getRequestMemberId,
 				PaymentRequest::getId,
-				(first, ignored) -> first
+				(first, duplicate) -> {
+					throw new IllegalStateException("중복된 PENDING 입금 확인 요청이 존재합니다.");
+				}
 			));
 	}
 

--- a/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestValidator.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestValidator.java
@@ -2,6 +2,7 @@ package com.dnd.moddo.event.application.impl;
 
 import org.springframework.stereotype.Component;
 
+import com.dnd.moddo.auth.model.exception.UserPermissionException;
 import com.dnd.moddo.event.domain.member.Member;
 import com.dnd.moddo.event.domain.paymentRequest.PaymentRequest;
 import com.dnd.moddo.event.domain.paymentRequest.PaymentRequestStatus;
@@ -9,7 +10,6 @@ import com.dnd.moddo.event.domain.paymentRequest.exception.DuplicatePendingPayme
 import com.dnd.moddo.event.domain.paymentRequest.exception.ManagerPaymentRequestNotAllowedException;
 import com.dnd.moddo.event.domain.paymentRequest.exception.PaymentRequestAlreadyApprovedException;
 import com.dnd.moddo.event.domain.paymentRequest.exception.PaymentRequestNotPendingException;
-import com.dnd.moddo.event.domain.paymentRequest.exception.PaymentRequestUnauthorizedException;
 import com.dnd.moddo.event.infrastructure.PaymentRequestRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class PaymentRequestValidator {
 
 	public void validateProcessRequest(PaymentRequest paymentRequest, Long userId) {
 		validatePendingStatus(paymentRequest);
-		validateTargetUser(paymentRequest, userId);
+		validateManagerPermission(paymentRequest, userId);
 	}
 
 	private void validateDuplicateRequest(Long settlementId, Long requestMemberId) {
@@ -66,9 +66,9 @@ public class PaymentRequestValidator {
 		}
 	}
 
-	private void validateTargetUser(PaymentRequest paymentRequest, Long userId) {
-		if (!paymentRequest.getTargetUser().getId().equals(userId)) {
-			throw new PaymentRequestUnauthorizedException(paymentRequest.getId(), userId);
+	private void validateManagerPermission(PaymentRequest paymentRequest, Long userId) {
+		if (!paymentRequest.getSettlement().isWriter(userId)) {
+			throw new UserPermissionException();
 		}
 	}
 }

--- a/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestValidator.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestValidator.java
@@ -26,8 +26,8 @@ public class PaymentRequestValidator {
 	}
 
 	public void validateProcessRequest(PaymentRequest paymentRequest, Long userId) {
-		validatePendingStatus(paymentRequest);
 		validateManagerPermission(paymentRequest, userId);
+		validatePendingStatus(paymentRequest);
 	}
 
 	private void validateDuplicateRequest(Long settlementId, Long requestMemberId) {

--- a/src/main/java/com/dnd/moddo/event/application/query/QuerySettlementService.java
+++ b/src/main/java/com/dnd/moddo/event/application/query/QuerySettlementService.java
@@ -2,11 +2,13 @@ package com.dnd.moddo.event.application.query;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 
 import com.dnd.moddo.common.cache.CacheExecutor;
 import com.dnd.moddo.common.cache.CacheKeys;
+import com.dnd.moddo.event.application.impl.PaymentRequestReader;
 import com.dnd.moddo.event.application.impl.SettlementReader;
 import com.dnd.moddo.event.application.impl.SettlementValidator;
 import com.dnd.moddo.event.domain.member.Member;
@@ -29,6 +31,7 @@ public class QuerySettlementService {
 	private static final Duration SETTLEMENT_LIST_CACHE_TTL = Duration.ofMinutes(5);
 
 	private final SettlementReader settlementReader;
+	private final PaymentRequestReader paymentRequestReader;
 	private final SettlementValidator settlementValidator;
 	private final CacheExecutor cacheExecutor;
 
@@ -36,7 +39,8 @@ public class QuerySettlementService {
 		Settlement settlement = settlementReader.read(settlementId);
 		settlementValidator.checkSettlementAuthor(settlement, userId);
 		List<Member> members = settlementReader.findBySettlement(settlementId);
-		return SettlementDetailResponse.of(settlement, members);
+		Map<Long, Long> paymentRequestIdByMemberId = paymentRequestReader.findPendingRequestIdByMemberId(settlementId);
+		return SettlementDetailResponse.of(settlement, members, paymentRequestIdByMemberId);
 	}
 
 	public SettlementHeaderResponse findBySettlementHeader(Long settlementId) {

--- a/src/main/java/com/dnd/moddo/event/infrastructure/PaymentRequestRepository.java
+++ b/src/main/java/com/dnd/moddo/event/infrastructure/PaymentRequestRepository.java
@@ -32,4 +32,15 @@ public interface PaymentRequestRepository extends JpaRepository<PaymentRequest, 
 
 	@Query("select pr from PaymentRequest pr where pr.targetUser.id = :targetUserId")
 	List<PaymentRequest> findByTargetUserId(@Param("targetUserId") Long targetUserId);
+
+	@Query("""
+		select pr
+		from PaymentRequest pr
+		where pr.settlement.id = :settlementId
+		  and pr.status = :status
+		""")
+	List<PaymentRequest> findBySettlementIdAndStatus(
+		@Param("settlementId") Long settlementId,
+		@Param("status") PaymentRequestStatus status
+	);
 }

--- a/src/main/java/com/dnd/moddo/event/presentation/response/SettlementDetailResponse.java
+++ b/src/main/java/com/dnd/moddo/event/presentation/response/SettlementDetailResponse.java
@@ -1,6 +1,7 @@
 package com.dnd.moddo.event.presentation.response;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.dnd.moddo.event.domain.member.Member;
@@ -9,11 +10,19 @@ import com.dnd.moddo.event.domain.settlement.Settlement;
 public record SettlementDetailResponse(
 	Long id,
 	String groupName,
-	List<MemberResponse> members
+	List<SettlementMemberResponse> members
 ) {
 	public static SettlementDetailResponse of(Settlement settlement, List<Member> members) {
-		List<MemberResponse> memberResponses = members.stream()
-			.map(MemberResponse::of)
+		return of(settlement, members, Map.of());
+	}
+
+	public static SettlementDetailResponse of(
+		Settlement settlement,
+		List<Member> members,
+		Map<Long, Long> paymentRequestIdByMemberId
+	) {
+		List<SettlementMemberResponse> memberResponses = members.stream()
+			.map(member -> SettlementMemberResponse.of(member, paymentRequestIdByMemberId.get(member.getId())))
 			.collect(Collectors.toList());
 		return new SettlementDetailResponse(
 			settlement.getId(),

--- a/src/main/java/com/dnd/moddo/event/presentation/response/SettlementMemberResponse.java
+++ b/src/main/java/com/dnd/moddo/event/presentation/response/SettlementMemberResponse.java
@@ -1,0 +1,34 @@
+package com.dnd.moddo.event.presentation.response;
+
+import java.time.LocalDateTime;
+
+import com.dnd.moddo.event.domain.member.ExpenseRole;
+import com.dnd.moddo.event.domain.member.Member;
+
+import lombok.Builder;
+
+@Builder
+public record SettlementMemberResponse(
+	Long id,
+	ExpenseRole role,
+	String name,
+	String profile,
+	Long userId,
+	Boolean isPaid,
+	LocalDateTime paidAt,
+	Long paymentRequestId
+) {
+
+	public static SettlementMemberResponse of(Member member, Long paymentRequestId) {
+		return SettlementMemberResponse.builder()
+			.id(member.getId())
+			.name(member.getName())
+			.role(member.getRole())
+			.userId(member.getUserId())
+			.isPaid(member.isPaid())
+			.paidAt(member.getPaidAt())
+			.paymentRequestId(paymentRequestId)
+			.profile(member.getProfileUrl())
+			.build();
+	}
+}

--- a/src/main/java/com/dnd/moddo/outbox/application/impl/OutboxEventPublishExecutor.java
+++ b/src/main/java/com/dnd/moddo/outbox/application/impl/OutboxEventPublishExecutor.java
@@ -62,7 +62,7 @@ public class OutboxEventPublishExecutor {
 		for (Member member : memberReader.findAssignedMembersBySettlementId(outboxEvent.getAggregateId())) {
 			Long targetUserId = member.getUserId();
 			eventTasks.add(EventTask.pending(outboxEvent, EventTaskType.REWARD_GRANT, targetUserId));
-			eventTasks.add(EventTask.pending(outboxEvent, EventTaskType.NOTIFICATION_SEND, targetUserId));
+			// eventTasks.add(EventTask.pending(outboxEvent, EventTaskType.NOTIFICATION_SEND, targetUserId));
 		}
 
 		if (!eventTasks.isEmpty()) {

--- a/src/test/java/com/dnd/moddo/domain/outbox/service/implementation/OutboxEventPublishExecutorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/outbox/service/implementation/OutboxEventPublishExecutorTest.java
@@ -74,14 +74,12 @@ class OutboxEventPublishExecutorTest {
 
 		ArgumentCaptor<List<EventTask>> captor = ArgumentCaptor.forClass(List.class);
 		verify(eventTaskCreator).createAll(captor.capture());
-		assertThat(captor.getValue()).hasSize(4);
+		assertThat(captor.getValue()).hasSize(2);
 		assertThat(captor.getValue())
 			.extracting(EventTask::getTaskType, EventTask::getTargetUserId)
 			.containsExactly(
 				tuple(EventTaskType.REWARD_GRANT, 20L),
-				tuple(EventTaskType.NOTIFICATION_SEND, 20L),
-				tuple(EventTaskType.REWARD_GRANT, 30L),
-				tuple(EventTaskType.NOTIFICATION_SEND, 30L)
+				tuple(EventTaskType.REWARD_GRANT, 30L)
 			);
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestReaderTest.java
@@ -100,6 +100,33 @@ class PaymentRequestReaderTest {
 		assertThat(second.totalAmount()).isEqualTo(5000L);
 	}
 
+	@Test
+	@DisplayName("정산의 대기 중인 입금 확인 요청 ID를 멤버 ID 기준으로 조회할 수 있다.")
+	void findPendingRequestIdByMemberId() {
+		Settlement settlement = mock(Settlement.class);
+		Member member = Member.builder()
+			.name("김반숙")
+			.profileId(1)
+			.settlement(settlement)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
+		PaymentRequest paymentRequest = PaymentRequest.builder()
+			.settlement(settlement)
+			.requestMember(member)
+			.targetUser(mock(com.dnd.moddo.user.domain.User.class))
+			.build();
+
+		setField(member, "id", 11L);
+		setField(paymentRequest, "id", 100L);
+
+		when(paymentRequestRepository.findBySettlementIdAndStatus(1L, PaymentRequestStatus.PENDING))
+			.thenReturn(List.of(paymentRequest));
+
+		java.util.Map<Long, Long> result = paymentRequestReader.findPendingRequestIdByMemberId(1L);
+
+		assertThat(result).containsEntry(11L, 100L);
+	}
+
 	private void setField(Object target, String fieldName, Object value) {
 		try {
 			java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestReaderTest.java
@@ -127,6 +127,39 @@ class PaymentRequestReaderTest {
 		assertThat(result).containsEntry(11L, 100L);
 	}
 
+	@Test
+	@DisplayName("같은 멤버의 대기 중인 입금 확인 요청이 중복되면 예외가 발생한다.")
+	void findPendingRequestIdByMemberIdFailWhenDuplicatePendingRequest() {
+		Settlement settlement = mock(Settlement.class);
+		Member member = Member.builder()
+			.name("김반숙")
+			.profileId(1)
+			.settlement(settlement)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
+		PaymentRequest first = PaymentRequest.builder()
+			.settlement(settlement)
+			.requestMember(member)
+			.targetUser(mock(com.dnd.moddo.user.domain.User.class))
+			.build();
+		PaymentRequest second = PaymentRequest.builder()
+			.settlement(settlement)
+			.requestMember(member)
+			.targetUser(mock(com.dnd.moddo.user.domain.User.class))
+			.build();
+
+		setField(member, "id", 11L);
+		setField(first, "id", 100L);
+		setField(second, "id", 101L);
+
+		when(paymentRequestRepository.findBySettlementIdAndStatus(1L, PaymentRequestStatus.PENDING))
+			.thenReturn(List.of(first, second));
+
+		assertThatThrownBy(() -> paymentRequestReader.findPendingRequestIdByMemberId(1L))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("중복된 PENDING 입금 확인 요청이 존재합니다.");
+	}
+
 	private void setField(Object target, String fieldName, Object value) {
 		try {
 			java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestValidatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestValidatorTest.java
@@ -76,12 +76,12 @@ class PaymentRequestValidatorTest {
 		PaymentRequest paymentRequest = mock(PaymentRequest.class);
 		Settlement settlement = mock(Settlement.class);
 
-		when(paymentRequest.getStatus()).thenReturn(PaymentRequestStatus.PENDING);
 		when(paymentRequest.getSettlement()).thenReturn(settlement);
 		when(settlement.isWriter(200L)).thenReturn(false);
 
 		assertThatThrownBy(() -> paymentRequestValidator.validateProcessRequest(paymentRequest, 200L))
 			.isInstanceOf(UserPermissionException.class);
+		verify(paymentRequest, never()).getStatus();
 	}
 
 	@Test
@@ -102,7 +102,10 @@ class PaymentRequestValidatorTest {
 	@DisplayName("대기 상태가 아니면 승인 또는 거절할 수 없다.")
 	void validateProcessRequestFailWhenNotPending() {
 		PaymentRequest paymentRequest = mock(PaymentRequest.class);
+		Settlement settlement = mock(Settlement.class);
 
+		when(paymentRequest.getSettlement()).thenReturn(settlement);
+		when(settlement.isWriter(100L)).thenReturn(true);
 		when(paymentRequest.getStatus()).thenReturn(PaymentRequestStatus.APPROVED);
 		when(paymentRequest.getId()).thenReturn(1L);
 

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestValidatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestValidatorTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dnd.moddo.auth.model.exception.UserPermissionException;
 import com.dnd.moddo.event.application.impl.PaymentRequestValidator;
 import com.dnd.moddo.event.domain.member.Member;
 import com.dnd.moddo.event.domain.paymentRequest.PaymentRequest;
@@ -18,9 +19,8 @@ import com.dnd.moddo.event.domain.paymentRequest.exception.DuplicatePendingPayme
 import com.dnd.moddo.event.domain.paymentRequest.exception.ManagerPaymentRequestNotAllowedException;
 import com.dnd.moddo.event.domain.paymentRequest.exception.PaymentRequestAlreadyApprovedException;
 import com.dnd.moddo.event.domain.paymentRequest.exception.PaymentRequestNotPendingException;
-import com.dnd.moddo.event.domain.paymentRequest.exception.PaymentRequestUnauthorizedException;
+import com.dnd.moddo.event.domain.settlement.Settlement;
 import com.dnd.moddo.event.infrastructure.PaymentRequestRepository;
-import com.dnd.moddo.user.domain.User;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentRequestValidatorTest {
@@ -71,18 +71,31 @@ class PaymentRequestValidatorTest {
 	}
 
 	@Test
-	@DisplayName("처리 대상 유저가 아니면 승인 또는 거절할 수 없다.")
-	void validateProcessRequestFailWhenUnauthorized() {
+	@DisplayName("총무가 아니면 승인 또는 거절할 수 없다.")
+	void validateProcessRequestFailWhenNotManager() {
 		PaymentRequest paymentRequest = mock(PaymentRequest.class);
-		User targetUser = mock(User.class);
+		Settlement settlement = mock(Settlement.class);
 
 		when(paymentRequest.getStatus()).thenReturn(PaymentRequestStatus.PENDING);
-		when(paymentRequest.getTargetUser()).thenReturn(targetUser);
-		when(paymentRequest.getId()).thenReturn(1L);
-		when(targetUser.getId()).thenReturn(100L);
+		when(paymentRequest.getSettlement()).thenReturn(settlement);
+		when(settlement.isWriter(200L)).thenReturn(false);
 
 		assertThatThrownBy(() -> paymentRequestValidator.validateProcessRequest(paymentRequest, 200L))
-			.isInstanceOf(PaymentRequestUnauthorizedException.class);
+			.isInstanceOf(UserPermissionException.class);
+	}
+
+	@Test
+	@DisplayName("총무이면 승인 또는 거절할 수 있다.")
+	void validateProcessRequestSuccessWhenManager() {
+		PaymentRequest paymentRequest = mock(PaymentRequest.class);
+		Settlement settlement = mock(Settlement.class);
+
+		when(paymentRequest.getStatus()).thenReturn(PaymentRequestStatus.PENDING);
+		when(paymentRequest.getSettlement()).thenReturn(settlement);
+		when(settlement.isWriter(100L)).thenReturn(true);
+
+		assertThatCode(() -> paymentRequestValidator.validateProcessRequest(paymentRequest, 100L))
+			.doesNotThrowAnyException();
 	}
 
 	@Test

--- a/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
@@ -24,6 +24,7 @@ import com.dnd.moddo.event.presentation.response.MemberResponse;
 import com.dnd.moddo.event.presentation.response.SettlementDetailResponse;
 import com.dnd.moddo.event.presentation.response.SettlementHeaderResponse;
 import com.dnd.moddo.event.presentation.response.SettlementListResponse;
+import com.dnd.moddo.event.presentation.response.SettlementMemberResponse;
 import com.dnd.moddo.event.presentation.response.SettlementResponse;
 import com.dnd.moddo.event.presentation.response.SettlementSaveResponse;
 import com.dnd.moddo.event.presentation.response.SettlementShareResponse;
@@ -90,10 +91,11 @@ public class SettlementControllerTest extends RestDocsTestSupport {
 	void getSettlement() throws Exception {
 		// given
 		SettlementDetailResponse response = new SettlementDetailResponse(1L, "모또 모임", List.of(
-			new MemberResponse(1L, MANAGER, "김모또", "https://moddo-s3.s3.amazonaws.com/profile/MODDO.png",
+			new SettlementMemberResponse(1L, MANAGER, "김모또", "https://moddo-s3.s3.amazonaws.com/profile/MODDO.png",
 				1L,
 				true,
-				LocalDateTime.now())
+				LocalDateTime.now(),
+				null)
 		));
 
 		given(loginUserArgumentResolver.supportsParameter(any()))
@@ -108,6 +110,7 @@ public class SettlementControllerTest extends RestDocsTestSupport {
 		// when & then
 		mockMvc.perform(get("/api/v1/groups/{code}", "code"))
 			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.members[0].paymentRequestId").value(Matchers.nullValue()))
 			.andDo(restDocs.document(
 				pathParameters(
 					parameterWithName("code").description("정산 코드")

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/QuerySettlementServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/QuerySettlementServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.common.cache.CacheExecutor;
+import com.dnd.moddo.event.application.impl.PaymentRequestReader;
 import com.dnd.moddo.event.application.impl.SettlementReader;
 import com.dnd.moddo.event.application.impl.SettlementValidator;
 import com.dnd.moddo.event.application.query.QuerySettlementService;
@@ -43,6 +44,9 @@ class QuerySettlementServiceTest {
 	private SettlementReader settlementReader;
 
 	@Mock
+	private PaymentRequestReader paymentRequestReader;
+
+	@Mock
 	private SettlementValidator settlementValidator;
 
 	@Mock
@@ -63,6 +67,7 @@ class QuerySettlementServiceTest {
 			.build();
 
 		setField(settlement, "id", 1L);
+		setField(member, "id", 10L);
 	}
 
 	@Test
@@ -71,6 +76,7 @@ class QuerySettlementServiceTest {
 		// Given
 		when(settlementReader.read(anyLong())).thenReturn(settlement);
 		when(settlementReader.findBySettlement(settlement.getId())).thenReturn(List.of(member));
+		when(paymentRequestReader.findPendingRequestIdByMemberId(settlement.getId())).thenReturn(java.util.Map.of(10L, 100L));
 		doNothing().when(settlementValidator).checkSettlementAuthor(settlement, 1L);
 
 		// When
@@ -82,9 +88,11 @@ class QuerySettlementServiceTest {
 		assertThat(response.groupName()).isEqualTo(settlement.getName());
 		assertThat(response.members()).hasSize(1);
 		assertThat(response.members().get(0).name()).isEqualTo(member.getName());
+		assertThat(response.members().get(0).paymentRequestId()).isEqualTo(100L);
 
 		verify(settlementReader, times(1)).read(1L);
 		verify(settlementReader, times(1)).findBySettlement(settlement.getId());
+		verify(paymentRequestReader, times(1)).findPendingRequestIdByMemberId(settlement.getId());
 		verify(settlementValidator, times(1)).checkSettlementAuthor(settlement, 1L);
 	}
 


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
fix/payment-request-settlement-detail -> develop

### 🔧변경 사항
- 정산 상세 조회 응답의 멤버 정보에 대기 중인 입금 확인 요청 ID를 포함했습니다.
- 입금 확인 승인/거절 시 정산 총무 권한을 검증하도록 변경했습니다.
- 미구현 상태인 `NOTIFICATION_SEND` 이벤트 태스크가 생성되지 않도록 주석 처리했습니다.
- 관련 서비스/컨트롤러/Outbox 테스트를 수정했습니다.

### 💬리뷰 요구사항(선택)
X

### ✅ 테스트
- `./gradlew --no-daemon test --tests '*MemberControllerTest' --tests '*SettlementControllerTest' --tests '*Settlement*' --tests '*PaymentRequest*'`
- `./gradlew --no-daemon test --tests '*OutboxEventPublishExecutorTest'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 정산 상세 조회 시 각 멤버별 대기 중인 결제요청 정보를 함께 제공합니다.

* **개선 사항**
  * 정산 관리 권한 검증 로직을 개선하여 정산 작성자 확인 기반으로 변경했습니다.

* **변경 사항**
  * 정산 완료 시 자동 알림 발송 기능을 일시 비활성화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->