### PR TITLE
(feature) : 정산 수동 완료 API 추가

### DIFF
--- a/src/docs/asciidoc/payment.adoc
+++ b/src/docs/asciidoc/payment.adoc
@@ -26,6 +26,36 @@ include::{snippets}/payment-request-controller-test/get-payment-requests/http-re
 
 include::{snippets}/payment-request-controller-test/get-payment-requests/response-body.adoc[]
 
+== 모임 입금 확인 요청 존재 여부 조회
+
+모임에 생성된 입금 확인 요청이 하나라도 있는지 조회할 수 있습니다.
+
+=== Example
+
+include::{snippets}/payment-request-controller-test/exists-payment-request/curl-request.adoc[]
+
+=== HTTP
+
+==== 요청
+
+include::{snippets}/payment-request-controller-test/exists-payment-request/http-request.adoc[]
+
+include::{snippets}/payment-request-controller-test/exists-payment-request/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/payment-request-controller-test/exists-payment-request/http-response.adoc[]
+
+=== Body
+
+==== 응답
+
+include::{snippets}/payment-request-controller-test/exists-payment-request/response-body.adoc[]
+
+==== 응답 필드
+
+include::{snippets}/payment-request-controller-test/exists-payment-request/response-fields.adoc[]
+
 == 입금 확인 요청 생성
 
 정산 참여자가 총무에게 입금 확인 요청을 보낼 수 있습니다.

--- a/src/docs/asciidoc/settlement.adoc
+++ b/src/docs/asciidoc/settlement.adoc
@@ -65,6 +65,26 @@ include::{snippets}/settlement-controller-test/update-account/request-body.adoc[
 
 include::{snippets}/settlement-controller-test/update-account/response-body.adoc[]
 
+== 정산 수동 완료
+
+총무가 정산을 수동으로 완료할 수 있습니다.
+
+=== Example
+
+include::{snippets}/settlement-controller-test/complete-settlement/curl-request.adoc[]
+
+=== HTTP
+
+==== 요청
+
+include::{snippets}/settlement-controller-test/complete-settlement/http-request.adoc[]
+
+include::{snippets}/settlement-controller-test/complete-settlement/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/settlement-controller-test/complete-settlement/http-response.adoc[]
+
 == 모임 조회
 
 모임 정보와 참여자 목록을 조회할 수 있습니다.

--- a/src/docs/asciidoc/settlement.adoc
+++ b/src/docs/asciidoc/settlement.adoc
@@ -91,6 +91,10 @@ include::{snippets}/settlement-controller-test/get-settlement/http-response.adoc
 
 include::{snippets}/settlement-controller-test/get-settlement/response-body.adoc[]
 
+==== 응답 필드
+
+include::{snippets}/settlement-controller-test/get-settlement/response-fields.adoc[]
+
 == 모임 상단 조회
 
 지출 내역 화면의 상단 정보를 조회할 수 있습니다.

--- a/src/main/java/com/dnd/moddo/event/application/command/CommandSettlementService.java
+++ b/src/main/java/com/dnd/moddo/event/application/command/CommandSettlementService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.common.cache.CacheEvictor;
 import com.dnd.moddo.event.application.impl.MemberCreator;
+import com.dnd.moddo.event.application.impl.SettlementCompletionProcessor;
 import com.dnd.moddo.event.application.impl.SettlementCreator;
 import com.dnd.moddo.event.application.impl.SettlementReader;
 import com.dnd.moddo.event.application.impl.SettlementUpdater;
@@ -28,6 +29,7 @@ public class CommandSettlementService {
 	private final SettlementValidator settlementValidator;
 	private final SettlementReader settlementReader;
 	private final MemberCreator memberCreator;
+	private final SettlementCompletionProcessor settlementCompletionProcessor;
 
 	public SettlementSaveResponse createSettlement(SettlementRequest request, Long userId) {
 		Settlement settlement = settlementCreator.createSettlement(request, userId);
@@ -42,5 +44,13 @@ public class CommandSettlementService {
 		settlement = settlementUpdater.updateAccount(request, settlement.getId());
 		cacheEvictor.evictSettlementHeader(settlementId);
 		return SettlementResponse.of(settlement);
+	}
+
+	public void completeSettlement(Long userId, Long settlementId) {
+		Settlement settlement = settlementReader.read(settlementId);
+		settlementValidator.checkSettlementAuthor(settlement, userId);
+		settlementCompletionProcessor.complete(settlementId);
+		cacheEvictor.evictSettlementHeader(settlementId);
+		cacheEvictor.evictSettlementListsBySettlement(settlementId);
 	}
 }

--- a/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestReader.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestReader.java
@@ -61,6 +61,10 @@ public class PaymentRequestReader {
 		return PaymentRequestsResponse.of(responses);
 	}
 
+	public boolean existsBySettlementId(Long settlementId) {
+		return paymentRequestRepository.existsBySettlementId(settlementId);
+	}
+
 	public Map<Long, Long> findPendingRequestIdByMemberId(Long settlementId) {
 		return paymentRequestRepository.findBySettlementIdAndStatus(settlementId, PaymentRequestStatus.PENDING)
 			.stream()

--- a/src/main/java/com/dnd/moddo/event/application/impl/SettlementCompletionProcessor.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/SettlementCompletionProcessor.java
@@ -1,8 +1,11 @@
 package com.dnd.moddo.event.application.impl;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dnd.moddo.event.domain.settlement.Settlement;
 import com.dnd.moddo.outbox.application.command.CommandOutboxEventService;
 import com.dnd.moddo.outbox.domain.event.type.AggregateType;
 import com.dnd.moddo.outbox.domain.event.type.OutboxEventType;
@@ -13,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SettlementCompletionProcessor {
 	private final MemberReader memberReader;
+	private final SettlementReader settlementReader;
 	private final SettlementUpdater settlementUpdater;
 	private final CommandOutboxEventService commandOutboxEventService;
 
@@ -22,8 +26,15 @@ public class SettlementCompletionProcessor {
 			return false;
 		}
 
-		boolean completed = settlementUpdater.complete(settlementId);
-		if (completed) {
+		return complete(settlementId);
+	}
+
+	@Transactional
+	public boolean complete(Long settlementId) {
+		Settlement settlement = settlementReader.read(settlementId);
+		LocalDateTime completedAt = LocalDateTime.now();
+		boolean completed = settlementUpdater.complete(settlementId, completedAt);
+		if (completed && settlement.isCompletedWithinDeadline(completedAt)) {
 			commandOutboxEventService.create(OutboxEventType.SETTLEMENT_COMPLETED, AggregateType.SETTLEMENT,
 				settlementId);
 		}

--- a/src/main/java/com/dnd/moddo/event/application/impl/SettlementUpdater.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/SettlementUpdater.java
@@ -1,5 +1,7 @@
 package com.dnd.moddo.event.application.impl;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +23,7 @@ public class SettlementUpdater {
 		return settlement;
 	}
 
-	public boolean complete(Long settlementId) {
-		return settlementRepository.markCompletedIfNotCompleted(settlementId) == 1;
+	public boolean complete(Long settlementId, LocalDateTime completedAt) {
+		return settlementRepository.markCompletedIfNotCompleted(settlementId, completedAt) == 1;
 	}
 }

--- a/src/main/java/com/dnd/moddo/event/application/query/QueryPaymentRequestService.java
+++ b/src/main/java/com/dnd/moddo/event/application/query/QueryPaymentRequestService.java
@@ -3,6 +3,7 @@ package com.dnd.moddo.event.application.query;
 import org.springframework.stereotype.Service;
 
 import com.dnd.moddo.event.application.impl.PaymentRequestReader;
+import com.dnd.moddo.event.presentation.response.PaymentRequestExistenceResponse;
 import com.dnd.moddo.event.presentation.response.PaymentRequestsResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -14,5 +15,9 @@ public class QueryPaymentRequestService {
 
 	public PaymentRequestsResponse findByTargetUserId(Long targetUserId) {
 		return paymentRequestReader.findByTargetUserId(targetUserId);
+	}
+
+	public PaymentRequestExistenceResponse existsBySettlementId(Long settlementId) {
+		return PaymentRequestExistenceResponse.of(paymentRequestReader.existsBySettlementId(settlementId));
 	}
 }

--- a/src/main/java/com/dnd/moddo/event/domain/settlement/Settlement.java
+++ b/src/main/java/com/dnd/moddo/event/domain/settlement/Settlement.java
@@ -54,12 +54,12 @@ public class Settlement {
 		String bank, String accountNumber, String code, LocalDateTime deadline) {
 		this.name = name;
 		this.writer = writer;
-		this.createdAt = createdAt;
+		this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
 		this.expiredAt = LocalDateTime.now().plusMonths(1);
 		this.bank = bank;
 		this.accountNumber = accountNumber;
 		this.code = code;
-		this.deadline = deadline;
+		this.deadline = deadline != null ? deadline : this.createdAt.plusDays(1);
 	}
 
 	public void updateAccount(SettlementAccountRequest request) {
@@ -78,5 +78,9 @@ public class Settlement {
 
 	public void complete() {
 		this.completedAt = LocalDateTime.now();
+	}
+
+	public boolean isCompletedWithinDeadline(LocalDateTime completedAt) {
+		return deadline != null && !completedAt.isAfter(deadline);
 	}
 }

--- a/src/main/java/com/dnd/moddo/event/infrastructure/PaymentRequestRepository.java
+++ b/src/main/java/com/dnd/moddo/event/infrastructure/PaymentRequestRepository.java
@@ -34,6 +34,13 @@ public interface PaymentRequestRepository extends JpaRepository<PaymentRequest, 
 	List<PaymentRequest> findByTargetUserId(@Param("targetUserId") Long targetUserId);
 
 	@Query("""
+		select count(pr) > 0
+		from PaymentRequest pr
+		where pr.settlement.id = :settlementId
+		""")
+	boolean existsBySettlementId(@Param("settlementId") Long settlementId);
+
+	@Query("""
 		select pr
 		from PaymentRequest pr
 		where pr.settlement.id = :settlementId

--- a/src/main/java/com/dnd/moddo/event/infrastructure/SettlementRepository.java
+++ b/src/main/java/com/dnd/moddo/event/infrastructure/SettlementRepository.java
@@ -66,11 +66,14 @@ public interface SettlementRepository extends JpaRepository<Settlement, Long> {
 	@Modifying
 	@Query("""
 			update Settlement s
-			   set s.completedAt = CURRENT_TIMESTAMP
+			   set s.completedAt = :completedAt
 			 where s.id = :settlementId
 			   and s.completedAt is null
-		""")
-	int markCompletedIfNotCompleted(@Param("settlementId") Long settlementId);
+	""")
+	int markCompletedIfNotCompleted(
+		@Param("settlementId") Long settlementId,
+		@Param("completedAt") LocalDateTime completedAt
+	);
 
 	default Long getIdByCode(String code) {
 		return findIdByCode(code).orElseThrow(() -> new GroupNotFoundException(code));

--- a/src/main/java/com/dnd/moddo/event/presentation/PaymentRequestController.java
+++ b/src/main/java/com/dnd/moddo/event/presentation/PaymentRequestController.java
@@ -13,6 +13,7 @@ import com.dnd.moddo.auth.presentation.response.LoginUserInfo;
 import com.dnd.moddo.event.application.command.CommandPaymentRequest;
 import com.dnd.moddo.event.application.query.QueryPaymentRequestService;
 import com.dnd.moddo.event.application.query.QuerySettlementService;
+import com.dnd.moddo.event.presentation.response.PaymentRequestExistenceResponse;
 import com.dnd.moddo.event.presentation.response.PaymentRequestResponse;
 import com.dnd.moddo.event.presentation.response.PaymentRequestsResponse;
 
@@ -41,6 +42,15 @@ public class PaymentRequestController {
 	) {
 		Long settlementId = querySettlementService.findIdByCode(code);
 		PaymentRequestResponse response = commandPaymentRequest.createPaymentRequest(settlementId, loginUser.userId());
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/groups/{code}/payments/exists")
+	public ResponseEntity<PaymentRequestExistenceResponse> existsPaymentRequest(
+		@PathVariable String code
+	) {
+		Long settlementId = querySettlementService.findIdByCode(code);
+		PaymentRequestExistenceResponse response = queryPaymentRequestService.existsBySettlementId(settlementId);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/moddo/event/presentation/SettlementController.java
+++ b/src/main/java/com/dnd/moddo/event/presentation/SettlementController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -60,6 +61,16 @@ public class SettlementController {
 			loginUser.userId(),
 			settlementId);
 		return ResponseEntity.ok(response);
+	}
+
+	@PatchMapping("/{code}/complete")
+	public ResponseEntity<Void> completeSettlement(
+		@PathVariable("code") String code,
+		@LoginUser LoginUserInfo loginUser
+	) {
+		Long settlementId = querySettlementService.findIdByCode(code);
+		commandSettlementService.completeSettlement(loginUser.userId(), settlementId);
+		return ResponseEntity.ok().build();
 	}
 
 	@GetMapping("/{code}")

--- a/src/main/java/com/dnd/moddo/event/presentation/response/PaymentRequestExistenceResponse.java
+++ b/src/main/java/com/dnd/moddo/event/presentation/response/PaymentRequestExistenceResponse.java
@@ -1,0 +1,9 @@
+package com.dnd.moddo.event.presentation.response;
+
+public record PaymentRequestExistenceResponse(
+	boolean exists
+) {
+	public static PaymentRequestExistenceResponse of(boolean exists) {
+		return new PaymentRequestExistenceResponse(exists);
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/controller/PaymentRequestControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/controller/PaymentRequestControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import com.dnd.moddo.auth.infrastructure.security.LoginUserArgumentResolver;
 import com.dnd.moddo.auth.presentation.response.LoginUserInfo;
 import com.dnd.moddo.event.domain.paymentRequest.PaymentRequestStatus;
+import com.dnd.moddo.event.presentation.response.PaymentRequestExistenceResponse;
 import com.dnd.moddo.event.presentation.response.PaymentRequestResponse;
 import com.dnd.moddo.event.presentation.response.PaymentRequestsResponse;
 import com.dnd.moddo.global.util.RestDocsTestSupport;
@@ -67,6 +68,29 @@ public class PaymentRequestControllerTest extends RestDocsTestSupport {
 					fieldWithPath("paymentRequests[].name").type(JsonFieldType.STRING).description("요청 참여자 이름"),
 					fieldWithPath("paymentRequests[].profileUrl").type(JsonFieldType.STRING).description("요청 참여자 프로필 URL"),
 					fieldWithPath("paymentRequests[].totalAmount").type(JsonFieldType.NUMBER).description("요청 금액")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("모임에 생성된 입금 확인 요청이 있는지 확인한다.")
+	void existsPaymentRequest() throws Exception {
+		String code = "code";
+		Long settlementId = 1L;
+		PaymentRequestExistenceResponse response = new PaymentRequestExistenceResponse(true);
+
+		when(querySettlementService.findIdByCode(code)).thenReturn(settlementId);
+		when(queryPaymentRequestService.existsBySettlementId(settlementId)).thenReturn(response);
+
+		mockMvc.perform(get("/api/v1/groups/{code}/payments/exists", code))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.exists").value(true))
+			.andDo(restDocs.document(
+				pathParameters(
+					parameterWithName("code").description("정산 코드")
+				),
+				responseFields(
+					fieldWithPath("exists").type(JsonFieldType.BOOLEAN).description("모임에 생성된 입금 확인 요청 존재 여부")
 				)
 			));
 	}

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/service/QueryPaymentRequestServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/service/QueryPaymentRequestServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.event.application.impl.PaymentRequestReader;
 import com.dnd.moddo.event.application.query.QueryPaymentRequestService;
+import com.dnd.moddo.event.presentation.response.PaymentRequestExistenceResponse;
 import com.dnd.moddo.event.presentation.response.PaymentRequestItemResponse;
 import com.dnd.moddo.event.presentation.response.PaymentRequestsResponse;
 
@@ -46,5 +47,16 @@ class QueryPaymentRequestServiceTest {
 
 		assertThat(result).isEqualTo(expected);
 		verify(paymentRequestReader).findByTargetUserId(1L);
+	}
+
+	@Test
+	@DisplayName("정산에 생성된 입금 확인 요청이 있는지 확인할 수 있다.")
+	void existsBySettlementId() {
+		when(paymentRequestReader.existsBySettlementId(1L)).thenReturn(true);
+
+		PaymentRequestExistenceResponse result = queryPaymentRequestService.existsBySettlementId(1L);
+
+		assertThat(result.exists()).isTrue();
+		verify(paymentRequestReader).existsBySettlementId(1L);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestReaderTest.java
@@ -128,6 +128,17 @@ class PaymentRequestReaderTest {
 	}
 
 	@Test
+	@DisplayName("정산에 생성된 입금 확인 요청이 있는지 확인할 수 있다.")
+	void existsBySettlementId() {
+		when(paymentRequestRepository.existsBySettlementId(1L)).thenReturn(true);
+
+		boolean result = paymentRequestReader.existsBySettlementId(1L);
+
+		assertThat(result).isTrue();
+		verify(paymentRequestRepository).existsBySettlementId(1L);
+	}
+
+	@Test
 	@DisplayName("같은 멤버의 대기 중인 입금 확인 요청이 중복되면 예외가 발생한다.")
 	void findPendingRequestIdByMemberIdFailWhenDuplicatePendingRequest() {
 		Settlement settlement = mock(Settlement.class);

--- a/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
@@ -87,6 +87,28 @@ public class SettlementControllerTest extends RestDocsTestSupport {
 	}
 
 	@Test
+	@DisplayName("정산을 수동 완료한다.")
+	void givenExistingSettlement_thenCompleteSettlement() throws Exception {
+		// given
+		given(loginUserArgumentResolver.supportsParameter(any()))
+			.willReturn(true);
+
+		given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
+			.willReturn(new LoginUserInfo(1L, "USER"));
+		given(querySettlementService.findIdByCode("code")).willReturn(100L);
+		willDoNothing().given(commandSettlementService).completeSettlement(1L, 100L);
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/groups/{code}/complete", "code"))
+			.andExpect(status().isOk())
+			.andDo(restDocs.document(
+				pathParameters(
+					parameterWithName("code").description("정산 코드")
+				)
+			));
+	}
+
+	@Test
 	@DisplayName("모임을 성공적으로 조회한다.")
 	void getSettlement() throws Exception {
 		// given

--- a/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
@@ -114,6 +114,19 @@ public class SettlementControllerTest extends RestDocsTestSupport {
 			.andDo(restDocs.document(
 				pathParameters(
 					parameterWithName("code").description("정산 코드")
+				),
+				responseFields(
+					fieldWithPath("id").description("정산 ID"),
+					fieldWithPath("groupName").description("정산 이름"),
+					fieldWithPath("members").description("모임원 목록"),
+					fieldWithPath("members[].id").description("모임원 ID"),
+					fieldWithPath("members[].role").description("모임원 역할"),
+					fieldWithPath("members[].name").description("모임원 이름"),
+					fieldWithPath("members[].profile").description("프로필 이미지 URL"),
+					fieldWithPath("members[].userId").description("사용자 ID").optional(),
+					fieldWithPath("members[].isPaid").description("정산 완료 여부"),
+					fieldWithPath("members[].paidAt").description("정산 완료 시각").optional(),
+					fieldWithPath("members[].paymentRequestId").description("대기 중인 입금 확인 요청 ID").optional()
 				)
 			));
 	}

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/CommandSettlementServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/CommandSettlementServiceTest.java
@@ -19,6 +19,7 @@ import com.dnd.moddo.common.cache.CacheEvictor;
 import com.dnd.moddo.event.application.command.CommandSettlementService;
 import com.dnd.moddo.event.application.impl.MemberCreator;
 import com.dnd.moddo.event.application.impl.MemberReader;
+import com.dnd.moddo.event.application.impl.SettlementCompletionProcessor;
 import com.dnd.moddo.event.application.impl.SettlementCreator;
 import com.dnd.moddo.event.application.impl.SettlementReader;
 import com.dnd.moddo.event.application.impl.SettlementUpdater;
@@ -54,6 +55,8 @@ class CommandSettlementServiceTest {
 	private MemberReader memberReader;
 	@Mock
 	private CacheEvictor cacheEvictor;
+	@Mock
+	private SettlementCompletionProcessor settlementCompletionProcessor;
 	@InjectMocks
 	private CommandSettlementService commandSettlementService;
 
@@ -124,6 +127,25 @@ class CommandSettlementServiceTest {
 		verify(settlementValidator, times(1)).checkSettlementAuthor(any(Settlement.class), anyLong());
 		verify(settlementUpdater, times(1)).updateAccount(any(SettlementAccountRequest.class), anyLong());
 		verify(cacheEvictor).evictSettlementHeader(settlement.getId());
+	}
+
+	@Test
+	@DisplayName("그룹을 수동 완료할 수 있다.")
+	void givenExistingSettlement_thenCompleteSettlement() {
+		// given
+		when(settlementReader.read(anyLong())).thenReturn(settlement);
+		doNothing().when(settlementValidator).checkSettlementAuthor(any(Settlement.class), anyLong());
+		when(settlementCompletionProcessor.complete(1L)).thenReturn(true);
+
+		// when
+		commandSettlementService.completeSettlement(1L, 1L);
+
+		// then
+		verify(settlementReader, times(1)).read(1L);
+		verify(settlementValidator, times(1)).checkSettlementAuthor(settlement, 1L);
+		verify(settlementCompletionProcessor, times(1)).complete(1L);
+		verify(cacheEvictor, times(1)).evictSettlementHeader(1L);
+		verify(cacheEvictor, times(1)).evictSettlementListsBySettlement(1L);
 	}
 
 }

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementCompletionProcessorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementCompletionProcessorTest.java
@@ -3,6 +3,8 @@ package com.dnd.moddo.domain.settlement.service.implementation;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.event.application.impl.MemberReader;
 import com.dnd.moddo.event.application.impl.SettlementCompletionProcessor;
+import com.dnd.moddo.event.application.impl.SettlementReader;
 import com.dnd.moddo.event.application.impl.SettlementUpdater;
+import com.dnd.moddo.event.domain.settlement.Settlement;
 import com.dnd.moddo.outbox.application.command.CommandOutboxEventService;
 import com.dnd.moddo.outbox.domain.event.type.AggregateType;
 import com.dnd.moddo.outbox.domain.event.type.OutboxEventType;
@@ -22,6 +26,9 @@ class SettlementCompletionProcessorTest {
 
 	@Mock
 	private MemberReader memberReader;
+
+	@Mock
+	private SettlementReader settlementReader;
 
 	@Mock
 	private SettlementUpdater settlementUpdater;
@@ -40,33 +47,65 @@ class SettlementCompletionProcessorTest {
 		boolean result = settlementCompletionProcessor.completeIfAllPaid(1L);
 
 		assertThat(result).isFalse();
-		verify(settlementUpdater, never()).complete(anyLong());
+		verify(settlementUpdater, never()).complete(anyLong(), any(LocalDateTime.class));
 		verify(commandOutboxEventService, never()).create(any(), any(), anyLong());
 	}
 
 	@Test
 	@DisplayName("정산이 방금 완료되면 아웃박스 이벤트를 생성한다.")
 	void createsOutboxEventWhenSettlementCompleted() {
+		Settlement settlement = createSettlement(LocalDateTime.now().plusDays(1));
+
 		when(memberReader.existsUnpaidMember(1L)).thenReturn(false);
-		when(settlementUpdater.complete(1L)).thenReturn(true);
+		when(settlementReader.read(1L)).thenReturn(settlement);
+		when(settlementUpdater.complete(eq(1L), any(LocalDateTime.class))).thenReturn(true);
 
 		boolean result = settlementCompletionProcessor.completeIfAllPaid(1L);
 
 		assertThat(result).isTrue();
-		verify(settlementUpdater).complete(1L);
+		verify(settlementUpdater).complete(eq(1L), any(LocalDateTime.class));
 		verify(commandOutboxEventService).create(OutboxEventType.SETTLEMENT_COMPLETED, AggregateType.SETTLEMENT, 1L);
 	}
 
 	@Test
 	@DisplayName("이미 완료된 정산이면 아웃박스 이벤트를 생성하지 않는다.")
 	void doesNotCreateOutboxEventWhenSettlementAlreadyCompleted() {
+		Settlement settlement = createSettlement(LocalDateTime.now().plusDays(1));
+
 		when(memberReader.existsUnpaidMember(1L)).thenReturn(false);
-		when(settlementUpdater.complete(1L)).thenReturn(false);
+		when(settlementReader.read(1L)).thenReturn(settlement);
+		when(settlementUpdater.complete(eq(1L), any(LocalDateTime.class))).thenReturn(false);
 
 		boolean result = settlementCompletionProcessor.completeIfAllPaid(1L);
 
 		assertThat(result).isFalse();
-		verify(settlementUpdater).complete(1L);
+		verify(settlementUpdater).complete(eq(1L), any(LocalDateTime.class));
 		verify(commandOutboxEventService, never()).create(any(), any(), anyLong());
+	}
+
+	@Test
+	@DisplayName("마감일 이후 완료된 정산이면 아웃박스 이벤트를 생성하지 않는다.")
+	void givenCompletedAfterDeadline_thenDoesNotCreateOutboxEvent() {
+		Settlement settlement = createSettlement(LocalDateTime.now().minusSeconds(1));
+
+		when(memberReader.existsUnpaidMember(1L)).thenReturn(false);
+		when(settlementReader.read(1L)).thenReturn(settlement);
+		when(settlementUpdater.complete(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+
+		boolean result = settlementCompletionProcessor.completeIfAllPaid(1L);
+
+		assertThat(result).isTrue();
+		verify(settlementUpdater).complete(eq(1L), any(LocalDateTime.class));
+		verify(commandOutboxEventService, never()).create(any(), any(), anyLong());
+	}
+
+	private Settlement createSettlement(LocalDateTime deadline) {
+		return Settlement.builder()
+			.name("group")
+			.writer(1L)
+			.createdAt(LocalDateTime.now().minusDays(1))
+			.code("code")
+			.deadline(deadline)
+			.build();
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementCreatorTest.java
@@ -85,6 +85,7 @@ class SettlementCreatorTest {
 		// then
 		assertThat(response).isNotNull();
 		assertThat(response.getName()).isEqualTo(request.name());
+		assertThat(response.getDeadline()).isNotNull();
 
 		verify(userRepository, times(1)).getById(userId);
 		verify(settlementRepository, times(1)).save(any(Settlement.class));

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/implementation/SettlementUpdaterTest.java
@@ -3,6 +3,8 @@ package com.dnd.moddo.domain.settlement.service.implementation;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,24 +61,26 @@ class SettlementUpdaterTest {
 	@Test
 	void completeSuccess() {
 		Long settlementId = 1L;
-		when(settlementRepository.markCompletedIfNotCompleted(settlementId)).thenReturn(1);
+		LocalDateTime completedAt = LocalDateTime.now();
+		when(settlementRepository.markCompletedIfNotCompleted(settlementId, completedAt)).thenReturn(1);
 
-		boolean result = settlementUpdater.complete(settlementId);
+		boolean result = settlementUpdater.complete(settlementId, completedAt);
 
 		assertThat(result).isTrue();
-		verify(settlementRepository).markCompletedIfNotCompleted(settlementId);
+		verify(settlementRepository).markCompletedIfNotCompleted(settlementId, completedAt);
 	}
 
 	@DisplayName("이미 완료된 정산이면 다시 완료 처리하지 않는다.")
 	@Test
 	void completeAlreadyCompletedSettlement() {
 		Long settlementId = 1L;
-		when(settlementRepository.markCompletedIfNotCompleted(settlementId)).thenReturn(0);
+		LocalDateTime completedAt = LocalDateTime.now();
+		when(settlementRepository.markCompletedIfNotCompleted(settlementId, completedAt)).thenReturn(0);
 
-		boolean result = settlementUpdater.complete(settlementId);
+		boolean result = settlementUpdater.complete(settlementId, completedAt);
 
 		assertThat(result).isFalse();
-		verify(settlementRepository).markCompletedIfNotCompleted(settlementId);
+		verify(settlementRepository).markCompletedIfNotCompleted(settlementId, completedAt);
 	}
 
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
fix/payment-request-settlement-detail -> develop

### 🔧변경 사항
- 정산 수동 완료 API를 추가했습니다.
- 정산 생성 시 마감일이 기본 생성되도록 보완했습니다.
- 정산은 마감 이후에도 완료 가능하지만, 캐릭터 지급 이벤트는 마감 기간 내 완료된 경우에만 생성되도록 변경했습니다.
- 수동 완료 API 및 마감 기간 내 보상 지급 조건에 대한 테스트와 REST Docs를 추가했습니다.

### 💬리뷰 요구사항(선택)
X

체크:
- 테스트 코드 포함 여부: O
- 불필요한 로그 제거: O
- 예외 처리 여부: O

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 정산 수동 완료 기능 추가
  * 모임 입금 확인 요청 존재 여부 조회 엔드포인트 추가

* **문서**
  * 정산 수동 완료 관련 API 문서 추가
  * 입금 확인 요청 존재 여부 조회 API 문서 추가
  * 모임 조회 응답 필드 설명 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moddo-kr/moddo-backend/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->