### PR TITLE
(fix) : 정산 완료 문서 스니펫 경로 수정

### DIFF
--- a/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/controller/SettlementControllerTest.java
@@ -2,6 +2,7 @@ package com.dnd.moddo.domain.settlement.controller;
 
 import static com.dnd.moddo.event.domain.member.ExpenseRole.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -101,7 +102,7 @@ public class SettlementControllerTest extends RestDocsTestSupport {
 		// when & then
 		mockMvc.perform(patch("/api/v1/groups/{code}/complete", "code"))
 			.andExpect(status().isOk())
-			.andDo(restDocs.document(
+			.andDo(document("settlement-controller-test/complete-settlement",
 				pathParameters(
 					parameterWithName("code").description("정산 코드")
 				)


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
fix/payment-request-settlement-detail -> develop

### 🔧변경 사항
정산 수동 완료 API 문서에서 참조하는 REST Docs snippet 이름과 실제 생성되는 snippet 이름이 달라 문서 빌드 시 unresolved directive가 발생하던 문제를 수정했습니다.

### 💬리뷰 요구사항(선택)
X

체크:
- 테스트 코드 포함 여부: O
- 불필요한 로그 제거: O
- 예외 처리 여부: O

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 테스트 코드의 문서화 방식을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moddo-kr/moddo-backend/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->