### PR TITLE
(fix) : 멤버 정산내역 입금 요청 상태 노출

### DIFF
--- a/src/main/java/com/dnd/moddo/event/application/query/QueryMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/event/application/query/QueryMemberExpenseService.java
@@ -45,9 +45,9 @@ public class QueryMemberExpenseService {
 
 	public MembersExpenseResponse findMemberExpenseDetailsBySettlementId(Long settlementId, Long userId) {
 		Settlement settlement = settlementReader.read(settlementId);
-		Map<Long, PaymentRequestSummaryResponse> paymentRequestByMemberId = settlement.isWriter(userId)
-			? paymentRequestReader.findLatestRequestByMemberId(settlementId)
-			: Map.of();
+		boolean isManager = settlement.isWriter(userId);
+		Map<Long, PaymentRequestSummaryResponse> paymentRequestByMemberId =
+			paymentRequestReader.findLatestRequestByMemberId(settlementId);
 
 		List<Member> members = memberReader.findAllBySettlementId(settlementId);
 
@@ -67,7 +67,8 @@ public class QueryMemberExpenseService {
 				key -> findMemberExpenseDetailByAppointmentMember(appointmentMemberById.get(key),
 					memberExpenses.get(key),
 					expenses,
-					paymentRequestByMemberId)
+					paymentRequestByMemberId,
+					isManager)
 			)
 			.filter(Objects::nonNull)
 			.toList();
@@ -85,18 +86,18 @@ public class QueryMemberExpenseService {
 
 	private MemberExpenseItemResponse findMemberExpenseDetailByAppointmentMember(
 		Member member, List<MemberExpense> memberExpenses, List<Expense> expenses,
-		Map<Long, PaymentRequestSummaryResponse> paymentRequestByMemberId) {
+		Map<Long, PaymentRequestSummaryResponse> paymentRequestByMemberId, boolean isManager) {
 
 		PaymentRequestSummaryResponse paymentRequest = paymentRequestByMemberId.get(member.getId());
 
 		if (memberExpenses == null) {
-			return MemberExpenseItemResponse.of(member, 0L, new ArrayList<>(), paymentRequest);
+			return MemberExpenseItemResponse.of(member, 0L, new ArrayList<>(), paymentRequest, isManager);
 		}
 
 		List<MemberExpenseDetailResponse> memberExpenseDetails = mapToMemberExpenseDetails(memberExpenses, expenses);
 		Long totalAmount = calculateTotalAmount(memberExpenses);
 
-		return MemberExpenseItemResponse.of(member, totalAmount, memberExpenseDetails, paymentRequest);
+		return MemberExpenseItemResponse.of(member, totalAmount, memberExpenseDetails, paymentRequest, isManager);
 	}
 
 	private Long calculateTotalAmount(List<MemberExpense> memberExpenses) {

--- a/src/main/java/com/dnd/moddo/event/presentation/response/MemberExpenseItemResponse.java
+++ b/src/main/java/com/dnd/moddo/event/presentation/response/MemberExpenseItemResponse.java
@@ -24,7 +24,7 @@ public record MemberExpenseItemResponse(
 	List<MemberExpenseDetailResponse> expenses
 ) {
 	public static MemberExpenseItemResponse of(Member member, Long totalAmount,
-		List<MemberExpenseDetailResponse> expenses, PaymentRequestSummaryResponse paymentRequest) {
+		List<MemberExpenseDetailResponse> expenses, PaymentRequestSummaryResponse paymentRequest, boolean isManager) {
 		return MemberExpenseItemResponse.builder()
 			.id(member.getId())
 			.role(member.getRole())
@@ -33,7 +33,7 @@ public record MemberExpenseItemResponse(
 			.profile(member.getProfileUrl())
 			.isPaid(member.isPaid())
 			.paidAt(member.getPaidAt())
-			.paymentRequestId(paymentRequest == null ? null : paymentRequest.id())
+			.paymentRequestId(paymentRequest == null || !isManager ? null : paymentRequest.id())
 			.paymentRequestStatus(paymentRequest == null ? null : paymentRequest.status())
 			.paymentRequestStatusLabel(paymentRequest == null ? null : paymentRequest.statusLabel())
 			.expenses(expenses).build();

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -166,6 +166,8 @@ class QueryMemberExpenseServiceTest {
 
 		when(member.getId()).thenReturn(1L);
 		when(settlementReader.read(groupId)).thenReturn(mockSettlement);
+		when(paymentRequestReader.findLatestRequestByMemberId(groupId))
+			.thenReturn(Map.of(1L, new PaymentRequestSummaryResponse(100L, PaymentRequestStatus.PENDING, "확인중")));
 		when(memberReader.findAllBySettlementId(eq(groupId))).thenReturn(List.of(member));
 		when(memberExpenseReader.findAllByAppointMemberIds(List.of(1L))).thenReturn(List.of());
 		when(expenseReader.findAllBySettlementId(groupId)).thenReturn(List.of());
@@ -178,11 +180,11 @@ class QueryMemberExpenseServiceTest {
 		assertThat(response).isNotNull();
 		assertThat(response.memberExpenses()).hasSize(1);
 		assertThat(response.memberExpenses().get(0).paymentRequestId()).isNull();
-		assertThat(response.memberExpenses().get(0).paymentRequestStatus()).isNull();
-		assertThat(response.memberExpenses().get(0).paymentRequestStatusLabel()).isNull();
+		assertThat(response.memberExpenses().get(0).paymentRequestStatus()).isEqualTo(PaymentRequestStatus.PENDING);
+		assertThat(response.memberExpenses().get(0).paymentRequestStatusLabel()).isEqualTo("확인중");
 
 		verify(settlementReader, times(1)).read(groupId);
-		verify(paymentRequestReader, never()).findLatestRequestByMemberId(anyLong());
+		verify(paymentRequestReader, times(1)).findLatestRequestByMemberId(groupId);
 		verify(memberReader, times(1)).findAllBySettlementId(groupId);
 	}
 


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
develop -> main

### 🔧변경 사항
- 멤버별 정산내역 조회 시 일반 멤버에게도 입금 확인 요청 상태와 표시명을 내려주도록 수정했습니다.
- 총무가 아닌 경우 입금 확인 요청 ID는 노출하지 않도록 유지했습니다.

### 💬리뷰 요구사항(선택)
X