### PR TITLE
(fix) : 캐시 응답 타입 변환 오류 수정

### DIFF
--- a/src/main/java/com/dnd/moddo/common/cache/CacheExecutor.java
+++ b/src/main/java/com/dnd/moddo/common/cache/CacheExecutor.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CacheExecutor {
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final Cache<String, Object> localCache;
+	private final ObjectMapper objectMapper;
 
 	@SuppressWarnings("unchecked")
 	public <T> T execute(String key, Duration ttl, Supplier<T> dbFallback) {
@@ -50,6 +52,44 @@ public class CacheExecutor {
 		T localValue = (T)localCache.getIfPresent(key);
 		if (localValue != null) {
 			return localValue;
+		}
+
+		T dbValue = dbFallback.get();
+		if (dbValue != null) {
+			localCache.put(key, dbValue);
+		}
+		return dbValue;
+	}
+
+	public <T> T execute(String key, Duration ttl, Class<T> type, Supplier<T> dbFallback) {
+		try {
+			Object redisValue = redisTemplate.opsForValue().get(key);
+			T convertedRedisValue = convertValue(redisValue, type);
+			if (convertedRedisValue != null) {
+				return convertedRedisValue;
+			}
+
+			T dbValue = dbFallback.get();
+			if (dbValue == null) {
+				return null;
+			}
+
+			try {
+				redisTemplate.opsForValue().set(key, dbValue, ttl);
+			} catch (Exception exception) {
+				log.warn("Redis write failed for key={}, storing fallback value locally", key, exception);
+				localCache.put(key, dbValue);
+			}
+
+			return dbValue;
+		} catch (Exception exception) {
+			log.warn("Redis read failed for key={}, switching to local fallback", key, exception);
+		}
+
+		Object localValue = localCache.getIfPresent(key);
+		T convertedLocalValue = convertValue(localValue, type);
+		if (convertedLocalValue != null) {
+			return convertedLocalValue;
 		}
 
 		T dbValue = dbFallback.get();
@@ -91,5 +131,15 @@ public class CacheExecutor {
 		} catch (Exception exception) {
 			log.warn("Redis prefix evict failed for prefix={}", prefix, exception);
 		}
+	}
+
+	private <T> T convertValue(Object value, Class<T> type) {
+		if (value == null) {
+			return null;
+		}
+		if (type.isInstance(value)) {
+			return type.cast(value);
+		}
+		return objectMapper.convertValue(value, type);
 	}
 }

--- a/src/main/java/com/dnd/moddo/common/config/CacheConfig.java
+++ b/src/main/java/com/dnd/moddo/common/config/CacheConfig.java
@@ -15,8 +15,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -70,6 +72,16 @@ public class CacheConfig {
 		ObjectMapper objectMapper = new ObjectMapper()
 			.registerModule(new JavaTimeModule())
 			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		objectMapper.activateDefaultTyping(
+			BasicPolymorphicTypeValidator.builder()
+				.allowIfSubType("com.dnd.moddo")
+				.allowIfSubType("java.lang")
+				.allowIfSubType("java.time")
+				.allowIfSubType("java.util")
+				.build(),
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			JsonTypeInfo.As.PROPERTY
+		);
 		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();

--- a/src/main/java/com/dnd/moddo/event/application/query/QuerySettlementService.java
+++ b/src/main/java/com/dnd/moddo/event/application/query/QuerySettlementService.java
@@ -49,6 +49,7 @@ public class QuerySettlementService {
 		return cacheExecutor.execute(
 			CacheKeys.settlementHeader(settlementId),
 			SETTLEMENT_HEADER_CACHE_TTL,
+			SettlementHeaderResponse.class,
 			() -> settlementReader.findByHeader(settlementId)
 		);
 	}

--- a/src/test/java/com/dnd/moddo/common/cache/CacheExecutorTest.java
+++ b/src/test/java/com/dnd/moddo/common/cache/CacheExecutorTest.java
@@ -1,0 +1,115 @@
+package com.dnd.moddo.common.cache;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.dnd.moddo.event.presentation.response.SettlementHeaderResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@ExtendWith(MockitoExtension.class)
+class CacheExecutorTest {
+	@Mock
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Mock
+	private ValueOperations<String, Object> valueOperations;
+
+	private Cache<String, Object> localCache;
+	private CacheExecutor cacheExecutor;
+
+	@BeforeEach
+	void setUp() {
+		ObjectMapper objectMapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule())
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		localCache = Caffeine.newBuilder().build();
+		cacheExecutor = new CacheExecutor(redisTemplate, localCache, objectMapper);
+	}
+
+	@Test
+	void givenRedisValueIsLinkedHashMap_thenConvertToResponseType() {
+		// given
+		String key = "settlement-header::1";
+		LocalDateTime deadline = LocalDateTime.of(2026, 6, 7, 12, 0);
+		LocalDateTime createdAt = LocalDateTime.of(2026, 6, 1, 12, 0);
+		Map<String, Object> cachedValue = new LinkedHashMap<>();
+		cachedValue.put("groupName", "모또 정산");
+		cachedValue.put("totalAmount", 10000L);
+		cachedValue.put("deadline", deadline.toString());
+		cachedValue.put("bank", "카카오뱅크");
+		cachedValue.put("accountNumber", "1234");
+		cachedValue.put("createdAt", createdAt.toString());
+		cachedValue.put("completedAt", null);
+
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+		given(valueOperations.get(key)).willReturn(cachedValue);
+
+		// when
+		SettlementHeaderResponse response = cacheExecutor.execute(
+			key,
+			Duration.ofMinutes(5),
+			SettlementHeaderResponse.class,
+			() -> {
+				throw new AssertionError("DB fallback must not be called");
+			}
+		);
+
+		// then
+		assertThat(response.groupName()).isEqualTo("모또 정산");
+		assertThat(response.totalAmount()).isEqualTo(10000L);
+		assertThat(response.deadline()).isEqualTo(deadline);
+		assertThat(response.bank()).isEqualTo("카카오뱅크");
+		assertThat(response.accountNumber()).isEqualTo("1234");
+		assertThat(response.createdAt()).isEqualTo(createdAt);
+		assertThat(response.completedAt()).isNull();
+		then(valueOperations).should(never()).set(anyString(), any(), any(Duration.class));
+	}
+
+	@Test
+	void givenRedisValueIsMissing_thenSaveDbFallbackValue() {
+		// given
+		String key = "settlement-header::1";
+		SettlementHeaderResponse fallback = new SettlementHeaderResponse(
+			"모또 정산",
+			10000L,
+			LocalDateTime.of(2026, 6, 7, 12, 0),
+			"카카오뱅크",
+			"1234",
+			LocalDateTime.of(2026, 6, 1, 12, 0),
+			null
+		);
+
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+		given(valueOperations.get(key)).willReturn(null);
+
+		// when
+		SettlementHeaderResponse response = cacheExecutor.execute(
+			key,
+			Duration.ofMinutes(5),
+			SettlementHeaderResponse.class,
+			() -> fallback
+		);
+
+		// then
+		assertThat(response).isEqualTo(fallback);
+		then(valueOperations).should(times(1)).set(eq(key), eq(fallback), eq(Duration.ofMinutes(5)));
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/settlement/service/QuerySettlementServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/settlement/service/QuerySettlementServiceTest.java
@@ -139,7 +139,8 @@ class QuerySettlementServiceTest {
 		SettlementHeaderResponse expectedResponse = new SettlementHeaderResponse(settlement.getName(), 1000L,
 			LocalDateTime.now().plusDays(1), settlement.getBank(), settlement.getAccountNumber(),
 			settlement.getCreatedAt(), settlement.getCompletedAt());
-		when(cacheExecutor.execute(anyString(), any(), any())).thenReturn(expectedResponse);
+		when(cacheExecutor.execute(anyString(), any(), eq(SettlementHeaderResponse.class), any()))
+			.thenReturn(expectedResponse);
 
 		// When
 		SettlementHeaderResponse response = querySettlementService.findBySettlementHeader(settlement.getId());
@@ -150,21 +151,22 @@ class QuerySettlementServiceTest {
 		assertThat(response.bank()).isEqualTo(settlement.getBank());
 		assertThat(response.accountNumber()).isEqualTo(settlement.getAccountNumber());
 
-		verify(cacheExecutor, times(1)).execute(anyString(), any(), any());
+		verify(cacheExecutor, times(1)).execute(anyString(), any(), eq(SettlementHeaderResponse.class), any());
 	}
 
 	@Test
 	@DisplayName("그룹 헤더를 찾을 수 없을 경우 예외가 발생한다.")
 	void FindBySettlementHeader_Failure_WhenHeaderNotFound() {
 		// Given
-		when(cacheExecutor.execute(anyString(), any(), any())).thenThrow(new RuntimeException("Header not found"));
+		when(cacheExecutor.execute(anyString(), any(), eq(SettlementHeaderResponse.class), any()))
+			.thenThrow(new RuntimeException("Header not found"));
 
 		// When & Then
 		assertThatThrownBy(() -> querySettlementService.findBySettlementHeader(1L))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessageContaining("Header not found");
 
-		verify(cacheExecutor, times(1)).execute(anyString(), any(), any());
+		verify(cacheExecutor, times(1)).execute(anyString(), any(), eq(SettlementHeaderResponse.class), any());
 	}
 
 	@DisplayName("group code가 유효할 때 group Id를 찾을 수 있다.")


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
develop -> main

### 🔧변경 사항
Redis 캐시에서 조회한 정산 헤더 응답이 LinkedHashMap으로 역직렬화되어 DTO 캐스팅에 실패하는 문제를 수정했습니다.

### 💬리뷰 요구사항(선택)
X

체크:
- 테스트 코드 포함 여부: O
- 불필요한 로그 제거: O
- 예외 처리 여부: O