### PR TITLE
(fix) : 입금 진행 후 지출 수정 방지

### DIFF
--- a/src/main/java/com/dnd/moddo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dnd/moddo/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MultipartException;
 
 import com.dnd.moddo.common.logging.DiscordMessage;
 import com.dnd.moddo.common.logging.ErrorNotifier;
@@ -85,6 +86,14 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity.badRequest()
 			.body(new ErrorResponse(400, e.getMessage()));
+	}
+
+	@ExceptionHandler(MultipartException.class)
+	public ResponseEntity<ErrorResponse> handleMultipartException(MultipartException exception) {
+		LoggingUtils.warn(exception);
+
+		return ResponseEntity.badRequest()
+			.body(new ErrorResponse(400, "잘못된 multipart 요청입니다."));
 	}
 
 	@ExceptionHandler({ModdoException.class})

--- a/src/main/java/com/dnd/moddo/common/logging/LoggingUtils.java
+++ b/src/main/java/com/dnd/moddo/common/logging/LoggingUtils.java
@@ -2,6 +2,7 @@ package com.dnd.moddo.common.logging;
 
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MultipartException;
 
 import com.dnd.moddo.common.exception.ModdoException;
 
@@ -20,6 +21,11 @@ public class LoggingUtils {
 	}
 
 	public static void warn(MethodArgumentTypeMismatchException exception) {
+		String message = getExceptionMessage(exception.getMessage());
+		log.warn(message + "\n \t {}", exception);
+	}
+
+	public static void warn(MultipartException exception) {
 		String message = getExceptionMessage(exception.getMessage());
 		log.warn(message + "\n \t {}", exception);
 	}

--- a/src/main/java/com/dnd/moddo/event/application/command/CommandExpenseService.java
+++ b/src/main/java/com/dnd/moddo/event/application/command/CommandExpenseService.java
@@ -9,9 +9,11 @@ import com.dnd.moddo.event.application.impl.ExpenseCreator;
 import com.dnd.moddo.event.application.impl.ExpenseDeleter;
 import com.dnd.moddo.event.application.impl.ExpenseReader;
 import com.dnd.moddo.event.application.impl.ExpenseUpdater;
+import com.dnd.moddo.event.application.impl.PaymentRequestReader;
 import com.dnd.moddo.event.application.impl.SettlementReader;
 import com.dnd.moddo.event.application.impl.SettlementValidator;
 import com.dnd.moddo.event.domain.expense.Expense;
+import com.dnd.moddo.event.domain.expense.exception.ExpenseModificationLockedException;
 import com.dnd.moddo.event.domain.settlement.Settlement;
 import com.dnd.moddo.event.presentation.request.ExpenseImageRequest;
 import com.dnd.moddo.event.presentation.request.ExpenseRequest;
@@ -33,8 +35,11 @@ public class CommandExpenseService {
 	private final CommandMemberExpenseService commandMemberExpenseService;
 	private final SettlementReader settlementReader;
 	private final SettlementValidator settlementValidator;
+	private final PaymentRequestReader paymentRequestReader;
 
 	public ExpensesResponse createExpenses(Long groupId, ExpensesRequest request) {
+		validateExpenseModifiable(groupId);
+
 		List<ExpenseResponse> expenses = request.expenses()
 			.stream()
 			.map(e -> createExpense(groupId, e))
@@ -58,6 +63,7 @@ public class CommandExpenseService {
 
 		Settlement settlement = settlementReader.read(settlementId);
 		settlementValidator.checkSettlementAuthor(settlement, userId);
+		validateExpenseModifiable(settlementId);
 
 		expense = expenseUpdater.update(expenseId, request);
 		List<MemberExpenseResponse> memberExpenseResponses = commandMemberExpenseService.update(expenseId,
@@ -70,6 +76,7 @@ public class CommandExpenseService {
 	public void updateImgUrl(Long userId, Long groupId, Long expenseId, ExpenseImageRequest request) {
 		Settlement settlement = settlementReader.read(groupId);
 		settlementValidator.checkSettlementAuthor(settlement, userId);
+		validateExpenseModifiable(groupId);
 		expenseUpdater.updateImgUrl(expenseId, request);
 	}
 
@@ -80,9 +87,16 @@ public class CommandExpenseService {
 
 		Settlement settlement = settlementReader.read(settlementId);
 		settlementValidator.checkSettlementAuthor(settlement, userId);
+		validateExpenseModifiable(settlementId);
 
 		commandMemberExpenseService.deleteAllByExpenseId(expenseId);
 		expenseDeleter.delete(expense);
 		cacheEvictor.evictSettlementHeader(settlementId);
+	}
+
+	private void validateExpenseModifiable(Long settlementId) {
+		if (paymentRequestReader.existsBySettlementId(settlementId)) {
+			throw new ExpenseModificationLockedException(settlementId);
+		}
 	}
 }

--- a/src/main/java/com/dnd/moddo/event/application/impl/MemberReader.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/MemberReader.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.event.domain.member.Member;
+import com.dnd.moddo.event.domain.member.ExpenseRole;
 import com.dnd.moddo.event.domain.member.exception.MemberNotFoundException;
 import com.dnd.moddo.event.domain.member.type.MemberSortType;
 import com.dnd.moddo.event.infrastructure.MemberQueryRepository;
@@ -43,6 +44,10 @@ public class MemberReader {
 
 	public boolean existsUnpaidMember(Long settlementId) {
 		return memberRepository.existsBySettlementIdAndIsPaidFalse(settlementId);
+	}
+
+	public boolean existsPaidParticipant(Long settlementId) {
+		return memberRepository.existsBySettlementIdAndRoleAndIsPaidTrue(settlementId, ExpenseRole.PARTICIPANT);
 	}
 
 	public List<Member> findAssignedMembersBySettlementId(Long settlementId) {

--- a/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestReader.java
+++ b/src/main/java/com/dnd/moddo/event/application/impl/PaymentRequestReader.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class PaymentRequestReader {
 	private final PaymentRequestRepository paymentRequestRepository;
 	private final MemberExpenseReader memberExpenseReader;
+	private final MemberReader memberReader;
 
 	public PaymentRequestsResponse findByTargetUserId(Long targetUserId) {
 		List<PaymentRequest> paymentRequests = paymentRequestRepository.findByTargetUserId(targetUserId)
@@ -63,7 +64,8 @@ public class PaymentRequestReader {
 	}
 
 	public boolean existsBySettlementId(Long settlementId) {
-		return paymentRequestRepository.existsBySettlementId(settlementId);
+		return paymentRequestRepository.existsBySettlementId(settlementId)
+			|| memberReader.existsPaidParticipant(settlementId);
 	}
 
 	public Map<Long, PaymentRequestSummaryResponse> findLatestRequestByMemberId(Long settlementId) {

--- a/src/main/java/com/dnd/moddo/event/domain/expense/exception/ExpenseModificationLockedException.java
+++ b/src/main/java/com/dnd/moddo/event/domain/expense/exception/ExpenseModificationLockedException.java
@@ -1,0 +1,11 @@
+package com.dnd.moddo.event.domain.expense.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.dnd.moddo.common.exception.ModdoException;
+
+public class ExpenseModificationLockedException extends ModdoException {
+	public ExpenseModificationLockedException(Long settlementId) {
+		super(HttpStatus.FORBIDDEN, "입금 확인 요청 또는 입금 완료 상태가 있어 지출내역을 수정할 수 없습니다. (Settlement ID: " + settlementId + ")");
+	}
+}

--- a/src/main/java/com/dnd/moddo/event/infrastructure/MemberRepository.java
+++ b/src/main/java/com/dnd/moddo/event/infrastructure/MemberRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.dnd.moddo.event.domain.member.Member;
 import com.dnd.moddo.event.domain.member.exception.MemberNotFoundException;
+import com.dnd.moddo.event.domain.member.ExpenseRole;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -38,6 +39,18 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 			  and gm.isPaid = false
 		""")
 	boolean existsBySettlementIdAndIsPaidFalse(@Param("settlementId") Long settlementId);
+
+	@Query("""
+			select count(gm) > 0
+			from Member gm
+			where gm.settlement.id = :settlementId
+			  and gm.role = :role
+			  and gm.isPaid = true
+		""")
+	boolean existsBySettlementIdAndRoleAndIsPaidTrue(
+		@Param("settlementId") Long settlementId,
+		@Param("role") ExpenseRole role
+	);
 
 	default Member getById(Long id) {
 		return findById(id)

--- a/src/test/java/com/dnd/moddo/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/dnd/moddo/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,42 @@
+package com.dnd.moddo.common.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartException;
+
+import com.dnd.moddo.common.logging.DiscordMessage;
+import com.dnd.moddo.common.logging.ErrorNotifier;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+	@InjectMocks
+	private GlobalExceptionHandler globalExceptionHandler;
+
+	@Mock
+	private ErrorNotifier errorNotifier;
+
+	@Test
+	void givenInvalidMultipartRequest_thenReturnBadRequestWithoutErrorNotification() {
+		// given
+		MultipartException exception = new MultipartException("Failed to parse multipart servlet request");
+
+		// when
+		ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleMultipartException(exception);
+
+		// then
+		assertThat(response.getStatusCode().value()).isEqualTo(400);
+		assertThat(response.getBody())
+			.isEqualTo(new ErrorResponse(400, "잘못된 multipart 요청입니다."));
+		then(errorNotifier).should(never()).notifyError(any(DiscordMessage.class));
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
@@ -22,9 +22,11 @@ import com.dnd.moddo.event.application.impl.ExpenseCreator;
 import com.dnd.moddo.event.application.impl.ExpenseDeleter;
 import com.dnd.moddo.event.application.impl.ExpenseReader;
 import com.dnd.moddo.event.application.impl.ExpenseUpdater;
+import com.dnd.moddo.event.application.impl.PaymentRequestReader;
 import com.dnd.moddo.event.application.impl.SettlementReader;
 import com.dnd.moddo.event.application.impl.SettlementValidator;
 import com.dnd.moddo.event.domain.expense.Expense;
+import com.dnd.moddo.event.domain.expense.exception.ExpenseModificationLockedException;
 import com.dnd.moddo.event.domain.expense.exception.ExpenseNotFoundException;
 import com.dnd.moddo.event.domain.expense.exception.ExpenseNotSettlementException;
 import com.dnd.moddo.event.domain.settlement.Settlement;
@@ -52,6 +54,8 @@ class CommandExpenseServiceTest {
 	private SettlementReader settlementReader;
 	@Mock
 	private SettlementValidator settlementValidator;
+	@Mock
+	private PaymentRequestReader paymentRequestReader;
 	@Mock
 	private CommandMemberExpenseService commandMemberExpenseService;
 	@Mock
@@ -117,6 +121,7 @@ class CommandExpenseServiceTest {
 		when(expenseReader.findByExpenseId(eq(expenseId))).thenReturn(mockExpense);
 		when(settlementReader.read(eq(groupId))).thenReturn(mockSettlement);
 		doNothing().when(settlementValidator).checkSettlementAuthor(eq(mockSettlement), eq(userId));
+		when(paymentRequestReader.existsBySettlementId(groupId)).thenReturn(false);
 
 		when(expenseUpdater.update(eq(expenseId), eq(expenseRequest))).thenReturn(mockExpense);
 		when(commandMemberExpenseService.update(eq(expenseId), any())).thenReturn(
@@ -128,8 +133,34 @@ class CommandExpenseServiceTest {
 		//then
 		assertThat(response).isNotNull();
 		verify(mockExpense, times(1)).validateSettlement(groupId);
+		verify(paymentRequestReader, times(1)).existsBySettlementId(groupId);
 		verify(expenseUpdater, times(1)).update(expenseId, expenseRequest);
 		verify(cacheEvictor, times(1)).evictSettlementHeader(groupId);
+	}
+
+	@DisplayName("입금 확인 요청 또는 입금 완료 참여자가 있으면 지출내역을 수정할 수 없다.")
+	@Test
+	void updateLockedByPaymentProgress() {
+		// given
+		Long userId = 1L;
+		Long settlementId = 1L;
+		Long expenseId = 10L;
+		ExpenseRequest expenseRequest = mock(ExpenseRequest.class);
+		Settlement mockSettlement = new Settlement(settlementId, userId, "정산", null, null, null, null, null, null, 1L,
+			"code");
+		Expense mockExpense = mock(Expense.class);
+
+		when(expenseReader.findByExpenseId(expenseId)).thenReturn(mockExpense);
+		when(settlementReader.read(settlementId)).thenReturn(mockSettlement);
+		when(paymentRequestReader.existsBySettlementId(settlementId)).thenReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> commandExpenseService.update(userId, expenseId, settlementId, expenseRequest))
+			.isInstanceOf(ExpenseModificationLockedException.class);
+
+		verify(expenseUpdater, never()).update(anyLong(), any());
+		verify(commandMemberExpenseService, never()).update(anyLong(), any());
+		verify(cacheEvictor, never()).evictSettlementHeader(anyLong());
 	}
 
 	@DisplayName("업데이트하려는 지출 내역을 찾을 수 없을때 예외를 발생시킨다.")
@@ -164,6 +195,7 @@ class CommandExpenseServiceTest {
 		when(expenseReader.findByExpenseId(eq(expenseId))).thenReturn(mockExpense);
 		when(settlementReader.read(eq(settlementId))).thenReturn(mockSettlement);
 		doNothing().when(settlementValidator).checkSettlementAuthor(eq(mockSettlement), eq(userId));
+		when(paymentRequestReader.existsBySettlementId(settlementId)).thenReturn(false);
 
 		doNothing().when(commandMemberExpenseService).deleteAllByExpenseId(eq(expenseId));
 		doNothing().when(expenseDeleter).delete(eq(mockExpense));
@@ -173,9 +205,34 @@ class CommandExpenseServiceTest {
 
 		//then
 		verify(mockExpense, times(1)).validateSettlement(settlementId);
+		verify(paymentRequestReader, times(1)).existsBySettlementId(settlementId);
 		verify(commandMemberExpenseService, times(1)).deleteAllByExpenseId(eq(expenseId));
 		verify(expenseDeleter, times(1)).delete(eq(mockExpense));
 		verify(cacheEvictor, times(1)).evictSettlementHeader(settlementId);
+	}
+
+	@DisplayName("입금 확인 요청 또는 입금 완료 참여자가 있으면 지출내역을 삭제할 수 없다.")
+	@Test
+	void deleteLockedByPaymentProgress() {
+		// given
+		Long userId = 1L;
+		Long settlementId = 1L;
+		Long expenseId = 10L;
+		Settlement mockSettlement = new Settlement(settlementId, userId, "정산", null, null, null, null, null, null, 1L,
+			"code");
+		Expense mockExpense = mock(Expense.class);
+
+		when(expenseReader.findByExpenseId(expenseId)).thenReturn(mockExpense);
+		when(settlementReader.read(settlementId)).thenReturn(mockSettlement);
+		when(paymentRequestReader.existsBySettlementId(settlementId)).thenReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> commandExpenseService.delete(userId, expenseId, settlementId))
+			.isInstanceOf(ExpenseModificationLockedException.class);
+
+		verify(commandMemberExpenseService, never()).deleteAllByExpenseId(anyLong());
+		verify(expenseDeleter, never()).delete(any());
+		verify(cacheEvictor, never()).evictSettlementHeader(anyLong());
 	}
 
 	@DisplayName("삭제하려는 지출내역이 해당 정산에 속하지 않으면 예외가 발생한다.")
@@ -251,6 +308,7 @@ class CommandExpenseServiceTest {
 
 		when(settlementReader.read(groupId)).thenReturn(mockSettlement);
 		doNothing().when(settlementValidator).checkSettlementAuthor(mockSettlement, userId);
+		when(paymentRequestReader.existsBySettlementId(groupId)).thenReturn(false);
 
 		// when
 		commandExpenseService.updateImgUrl(userId, groupId, expenseId, request);
@@ -258,6 +316,7 @@ class CommandExpenseServiceTest {
 		// then
 		verify(settlementReader, times(1)).read(groupId);
 		verify(settlementValidator, times(1)).checkSettlementAuthor(mockSettlement, userId);
+		verify(paymentRequestReader, times(1)).existsBySettlementId(groupId);
 		verify(expenseUpdater, times(1)).updateImgUrl(expenseId, request);
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/service/QueryPaymentRequestServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/service/QueryPaymentRequestServiceTest.java
@@ -50,7 +50,7 @@ class QueryPaymentRequestServiceTest {
 	}
 
 	@Test
-	@DisplayName("정산에 생성된 입금 확인 요청이 있는지 확인할 수 있다.")
+	@DisplayName("정산에 생성된 입금 확인 요청 또는 입금 완료 참여자가 있는지 확인할 수 있다.")
 	void existsBySettlementId() {
 		when(paymentRequestReader.existsBySettlementId(1L)).thenReturn(true);
 

--- a/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/paymentRequest/service/implementation/PaymentRequestReaderTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.event.application.impl.MemberExpenseReader;
+import com.dnd.moddo.event.application.impl.MemberReader;
 import com.dnd.moddo.event.application.impl.PaymentRequestReader;
 import com.dnd.moddo.event.domain.member.ExpenseRole;
 import com.dnd.moddo.event.domain.member.Member;
@@ -34,6 +35,9 @@ class PaymentRequestReaderTest {
 
 	@Mock
 	private MemberExpenseReader memberExpenseReader;
+
+	@Mock
+	private MemberReader memberReader;
 
 	@InjectMocks
 	private PaymentRequestReader paymentRequestReader;
@@ -140,6 +144,20 @@ class PaymentRequestReaderTest {
 
 		assertThat(result).isTrue();
 		verify(paymentRequestRepository).existsBySettlementId(1L);
+		verify(memberReader, never()).existsPaidParticipant(1L);
+	}
+
+	@Test
+	@DisplayName("입금 확인 요청이 없어도 입금 완료 참여자가 있으면 수정 잠금 상태로 판단한다.")
+	void existsBySettlementIdWhenPaidParticipantExists() {
+		when(paymentRequestRepository.existsBySettlementId(1L)).thenReturn(false);
+		when(memberReader.existsPaidParticipant(1L)).thenReturn(true);
+
+		boolean result = paymentRequestReader.existsBySettlementId(1L);
+
+		assertThat(result).isTrue();
+		verify(paymentRequestRepository).existsBySettlementId(1L);
+		verify(memberReader).existsPaidParticipant(1L);
 	}
 
 	@Test


### PR DESCRIPTION
### #️⃣연관된 이슈
X

### 🔀반영 브랜치
fix/expense-lock-payment-progress -> develop

### 🔧변경 사항
- 입금 확인 요청 또는 참여자 입금 완료 상태가 있으면 지출 생성/수정/삭제/이미지 수정을 차단합니다.
- 기존 입금 확인 요청 존재 여부 조회 API가 참여자 입금 완료 상태까지 함께 반영하도록 변경했습니다.
- 잘못된 multipart 요청은 400으로 처리해 서버 에러 알림이 발생하지 않도록 했습니다.
- 관련 단위 테스트를 추가/수정했습니다.

### 💬리뷰 요구사항(선택)
X

체크:
- 테스트 코드 포함 여부: O
- 불필요한 로그 제거: O
- 예외 처리 여부: O

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 잘못된 multipart 요청이 발생하면 경고를 기록하고, 안내 메시지와 함께 `400 Bad Request` 응답을 반환합니다.
  - 입금 확인 요청이 진행 중이거나 입금 완료 참가자가 있는 정산은 지출 내역의 생성·수정·삭제 및 이미지 변경이 제한됩니다.
  - 변경이 제한된 경우 명확한 오류 응답이 제공됩니다.

- **테스트**
  - multipart 오류 응답과 지출 변경 제한 시나리오에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->